### PR TITLE
Conditionally compile api.c and python_api.c contents.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+language: c
+compiler: clang
+
+addons:
+  apt:
+    packages:
+    - libconfig-dev
+    - libqrencode-dev
+
+cache:
+  directories:
+  - $HOME/cache
+
+install:
+# Where to find libraries.
+- export LD_LIBRARY_PATH=$HOME/cache/usr/lib
+- export PKG_CONFIG_PATH=$HOME/cache/usr/lib/pkgconfig
+# c-sodium
+- git clone --depth=1 --branch=stable https://github.com/jedisct1/libsodium
+- test -f $HOME/cache/usr/lib/libsodium.so || (cd libsodium && ./configure --prefix=$HOME/cache/usr && make install -j$(nproc))
+# c-toxcore
+- git clone --depth=1 https://github.com/TokTok/c-toxcore
+- test -f $HOME/cache/usr/lib/libtoxcore.so || (cd c-toxcore && cmake -B_build -H. -DCMAKE_INSTALL_PREFIX:PATH=$HOME/cache/usr -DBUILD_TOXAV=0 && make -C_build install -j$(nproc))
+
+script:
+- make

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ CFG_DIR = $(BASE_DIR)/cfg
 
 -include $(CFG_DIR)/global_vars.mk
 
-LIBS = libtoxcore ncursesw libconfig libqrencode
+LIBS = toxcore ncursesw libconfig libqrencode
 
 CFLAGS = -std=gnu99 -pthread -Wall -g -fstack-protector-all
 CFLAGS += '-DTOXICVER="$(VERSION)"' -DHAVE_WIDECHAR -D_XOPEN_SOURCE_EXTENDED -D_FILE_OFFSET_BITS=64

--- a/src/api.c
+++ b/src/api.c
@@ -36,7 +36,6 @@
 
 #ifdef PYTHON
 #include "python_api.h"
-#endif /* PYTHON */
 
 Tox              *user_tox;
 static WINDOW    *cur_window;
@@ -208,3 +207,4 @@ void invoke_autoruns(WINDOW *window, ToxWindow *self)
 
     closedir(d);
 }
+#endif /* PYTHON */

--- a/src/python_api.c
+++ b/src/python_api.c
@@ -23,7 +23,6 @@
 #ifdef PYTHON
 #include <Python.h>
 #include "api.h"
-#endif /* PYTHON */
 
 #include "execute.h"
 
@@ -345,3 +344,4 @@ void python_draw_handler_help(WINDOW *win)
             wprintw(win, "  %-29s: %.50s\n", cur->name, cur->help);
     }
 }
+#endif /* PYTHON */


### PR DESCRIPTION
Based on `-DPYTHON`, instead of based on which files are listed in the
source list. This simplifies people's lives when compiling from the
command line with `cc *.c`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxic/1)
<!-- Reviewable:end -->
