### PR TITLE
Rename callback implementations to be of the form `on_$event`.

### DIFF
--- a/src/audio_call.c
+++ b/src/audio_call.c
@@ -90,15 +90,11 @@ static int set_call(Call *call, bool start)
     return 0;
 }
 
-void call_cb(ToxAV *av, uint32_t friend_number, bool audio_enabled, bool video_enabled,
+void on_call(ToxAV *av, uint32_t friend_number, bool audio_enabled, bool video_enabled,
              void *user_data);
-void callstate_cb(ToxAV *av, uint32_t friend_number, uint32_t state, void *user_data);
-void receive_audio_frame_cb(ToxAV *av, uint32_t friend_number, int16_t const *pcm, size_t sample_count,
+void on_call_state(ToxAV *av, uint32_t friend_number, uint32_t state, void *user_data);
+void on_audio_receive_frame(ToxAV *av, uint32_t friend_number, int16_t const *pcm, size_t sample_count,
                             uint8_t channels, uint32_t sampling_rate, void *user_data);
-void receive_video_frame_cb(ToxAV *av, uint32_t friend_number,
-                            uint16_t width, uint16_t height,
-                            uint8_t const *y, uint8_t const *u, uint8_t const *v, uint8_t const *a,
-                            int32_t ystride, int32_t ustride, int32_t vstride, int32_t astride, void *user_data);
 
 void callback_recv_invite(Tox *m, uint32_t friend_number);
 void callback_recv_ringing(uint32_t friend_number);
@@ -152,9 +148,9 @@ ToxAV *init_audio(ToxWindow *self, Tox *tox)
         return CallControl.av = NULL;
     }
 
-    toxav_callback_call(CallControl.av, call_cb, tox);
-    toxav_callback_call_state(CallControl.av, callstate_cb, NULL);
-    toxav_callback_audio_receive_frame(CallControl.av, receive_audio_frame_cb, NULL);
+    toxav_callback_call(CallControl.av, on_call, tox);
+    toxav_callback_call_state(CallControl.av, on_call_state, NULL);
+    toxav_callback_audio_receive_frame(CallControl.av, on_audio_receive_frame, NULL);
 
     return CallControl.av;
 }
@@ -280,14 +276,14 @@ int stop_transmission(Call *call, uint32_t friend_number)
 /*
  * Callbacks
  */
-void call_cb(ToxAV *av, uint32_t friend_number, bool audio_enabled, bool video_enabled, void *user_data)
+void on_call(ToxAV *av, uint32_t friend_number, bool audio_enabled, bool video_enabled, void *user_data)
 {
     Tox *m = (Tox *) user_data;
     CallControl.pending_call = true;
     callback_recv_invite(m, friend_number);
 }
 
-void callstate_cb(ToxAV *av, uint32_t friend_number, uint32_t state, void *user_data)
+void on_call_state(ToxAV *av, uint32_t friend_number, uint32_t state, void *user_data)
 {
     CallControl.call_state = state;
 
@@ -348,7 +344,7 @@ void callstate_cb(ToxAV *av, uint32_t friend_number, uint32_t state, void *user_
     }
 }
 
-void receive_audio_frame_cb(ToxAV *av, uint32_t friend_number,
+void on_audio_receive_frame(ToxAV *av, uint32_t friend_number,
                             int16_t const *pcm, size_t sample_count,
                             uint8_t channels, uint32_t sampling_rate, void *user_data)
 {

--- a/src/global_commands.c
+++ b/src/global_commands.c
@@ -71,7 +71,7 @@ void cmd_accept(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[
         return;
     } else {
         line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Friend request accepted.");
-        on_friendadded(m, friendnum, true);
+        on_friend_added(m, friendnum, true);
     }
 
     memset(&FrndRequests.request[req], 0, sizeof(struct friend_request));
@@ -127,7 +127,7 @@ void cmd_add_helper(ToxWindow *self, Tox *m, const char *id_bin, const char *msg
 
         case TOX_ERR_FRIEND_ADD_OK:
             errmsg = "Friend request sent.";
-            on_friendadded(m, f_num, true);
+            on_friend_added(m, f_num, true);
             break;
 
         case TOX_ERR_FRIEND_ADD_NULL:

--- a/src/prompt.c
+++ b/src/prompt.c
@@ -137,7 +137,7 @@ void kill_prompt_window(ToxWindow *self)
 }
 
 /* callback: Updates own connection status in prompt statusbar */
-void prompt_onSelfConnectionChange(Tox *m, TOX_CONNECTION connection_status, void *userdata)
+void on_self_connection_status(Tox *m, TOX_CONNECTION connection_status, void *userdata)
 {
     StatusBar *statusbar = prompt->stb;
     statusbar->connection = connection_status;

--- a/src/prompt.h
+++ b/src/prompt.h
@@ -51,7 +51,7 @@ void prompt_update_connectionstatus(ToxWindow *prompt, bool is_connected);
 void kill_prompt_window(ToxWindow *self);
 
 /* callback: Updates own connection status in prompt statusbar */
-void prompt_onSelfConnectionChange(Tox *m, TOX_CONNECTION connection_status, void *userdata);
+void on_self_connection_status(Tox *m, TOX_CONNECTION connection_status, void *userdata);
 
 /* Returns our own connection status */
 TOX_CONNECTION prompt_selfConnectionStatus(void);

--- a/src/toxic.c
+++ b/src/toxic.c
@@ -586,23 +586,23 @@ int store_data(Tox *m, const char *path)
 
 static void init_tox_callbacks(Tox *m)
 {
-    tox_callback_self_connection_status(m, prompt_onSelfConnectionChange);
-    tox_callback_friend_connection_status(m, on_connectionchange);
-    tox_callback_friend_typing(m, on_typing_change);
-    tox_callback_friend_request(m, on_request);
-    tox_callback_friend_message(m, on_message);
-    tox_callback_friend_name(m, on_nickchange);
-    tox_callback_friend_status(m, on_statuschange);
-    tox_callback_friend_status_message(m, on_statusmessagechange);
-    tox_callback_friend_read_receipt(m, on_read_receipt);
-    tox_callback_conference_invite(m, on_groupinvite);
-    tox_callback_conference_message(m, on_groupmessage);
-    tox_callback_conference_peer_list_changed(m, on_group_namelistchange);
-    tox_callback_conference_peer_name(m, on_group_peernamechange);
-    tox_callback_conference_title(m, on_group_titlechange);
+    tox_callback_self_connection_status(m, on_self_connection_status);
+    tox_callback_friend_connection_status(m, on_friend_connection_status);
+    tox_callback_friend_typing(m, on_friend_typing);
+    tox_callback_friend_request(m, on_friend_request);
+    tox_callback_friend_message(m, on_friend_message);
+    tox_callback_friend_name(m, on_friend_name);
+    tox_callback_friend_status(m, on_friend_status);
+    tox_callback_friend_status_message(m, on_friend_status_message);
+    tox_callback_friend_read_receipt(m, on_friend_read_receipt);
+    tox_callback_conference_invite(m, on_conference_invite);
+    tox_callback_conference_message(m, on_conference_message);
+    tox_callback_conference_peer_list_changed(m, on_conference_peer_list_changed);
+    tox_callback_conference_peer_name(m, on_conference_peer_name);
+    tox_callback_conference_title(m, on_conference_title);
     tox_callback_file_recv(m, on_file_recv);
     tox_callback_file_chunk_request(m, on_file_chunk_request);
-    tox_callback_file_recv_control(m, on_file_control);
+    tox_callback_file_recv_control(m, on_file_recv_control);
     tox_callback_file_recv_chunk(m, on_file_recv_chunk);
 }
 

--- a/src/toxic.h
+++ b/src/toxic.h
@@ -105,32 +105,32 @@ void exit_toxic_err(const char *errmsg, int errcode);
 int store_data(Tox *m, const char *path);
 
 /* callbacks */
-void on_request(Tox *m, const uint8_t *public_key, const uint8_t *data, size_t length, void *userdata);
-void on_connectionchange(Tox *m, uint32_t friendnumber, TOX_CONNECTION status, void *userdata);
-void on_message(Tox *m, uint32_t friendnumber, TOX_MESSAGE_TYPE type, const uint8_t *string, size_t length,
-                void *userdata);
-void on_action(Tox *m, uint32_t friendnumber, const uint8_t *string, size_t length, void *userdata);
-void on_nickchange(Tox *m, uint32_t friendnumber, const uint8_t *string, size_t length, void *userdata);
-void on_statuschange(Tox *m, uint32_t friendnumber, TOX_USER_STATUS status, void *userdata);
-void on_statusmessagechange(Tox *m, uint32_t friendnumber, const uint8_t *string, size_t length, void *userdata);
-void on_friendadded(Tox *m, uint32_t friendnumber, bool sort);
-void on_groupmessage(Tox *m, uint32_t groupnumber, uint32_t peernumber, TOX_MESSAGE_TYPE type,
-                     const uint8_t *message, size_t length, void *userdata);
-void on_groupinvite(Tox *m, uint32_t friendnumber, TOX_CONFERENCE_TYPE type, const uint8_t *group_pub_key,
-                    size_t length, void *userdata);
-void on_group_namelistchange(Tox *m, uint32_t groupnumber, void *userdata);
-void on_group_peernamechange(Tox *m, uint32_t groupnumber, uint32_t peernumber, const uint8_t *name,
+void on_friend_request(Tox *m, const uint8_t *public_key, const uint8_t *data, size_t length, void *userdata);
+void on_friend_connection_status(Tox *m, uint32_t friendnumber, TOX_CONNECTION status, void *userdata);
+void on_friend_message(Tox *m, uint32_t friendnumber, TOX_MESSAGE_TYPE type, const uint8_t *string, size_t length,
+                       void *userdata);
+void on_friend_name(Tox *m, uint32_t friendnumber, const uint8_t *string, size_t length, void *userdata);
+void on_friend_status(Tox *m, uint32_t friendnumber, TOX_USER_STATUS status, void *userdata);
+void on_friend_status_message(Tox *m, uint32_t friendnumber, const uint8_t *string, size_t length, void *userdata);
+void on_friend_added(Tox *m, uint32_t friendnumber, bool sort);
+void on_conference_message(Tox *m, uint32_t groupnumber, uint32_t peernumber, TOX_MESSAGE_TYPE type,
+                           const uint8_t *message, size_t length, void *userdata);
+void on_conference_invite(Tox *m, uint32_t friendnumber, TOX_CONFERENCE_TYPE type, const uint8_t *group_pub_key,
+                          size_t length, void *userdata);
+void on_conference_peer_list_changed(Tox *m, uint32_t groupnumber, void *userdata);
+void on_conference_peer_name(Tox *m, uint32_t groupnumber, uint32_t peernumber, const uint8_t *name,
                              size_t length, void *userdata);
-void on_group_titlechange(Tox *m, uint32_t groupnumber, uint32_t peernumber, const uint8_t *title, size_t length,
-                          void *userdata);
+void on_conference_title(Tox *m, uint32_t groupnumber, uint32_t peernumber, const uint8_t *title, size_t length,
+                         void *userdata);
 void on_file_chunk_request(Tox *m, uint32_t friendnumber, uint32_t filenumber, uint64_t position, size_t length,
                            void *userdata);
 void on_file_recv_chunk(Tox *m, uint32_t friendnumber, uint32_t filenumber, uint64_t position, const uint8_t *data,
                         size_t length, void *userdata);
-void on_file_control(Tox *m, uint32_t friendnumber, uint32_t filenumber, TOX_FILE_CONTROL control, void *userdata);
+void on_file_recv_control(Tox *m, uint32_t friendnumber, uint32_t filenumber, TOX_FILE_CONTROL control,
+                          void *userdata);
 void on_file_recv(Tox *m, uint32_t friendnumber, uint32_t filenumber, uint32_t kind, uint64_t file_size,
                   const uint8_t *filename, size_t filename_length, void *userdata);
-void on_typing_change(Tox *m, uint32_t friendnumber, bool is_typing, void *userdata);
-void on_read_receipt(Tox *m, uint32_t friendnumber, uint32_t receipt, void *userdata);
+void on_friend_typing(Tox *m, uint32_t friendnumber, bool is_typing, void *userdata);
+void on_friend_read_receipt(Tox *m, uint32_t friendnumber, uint32_t receipt, void *userdata);
 
 #endif  /* #define TOXIC_H */

--- a/src/video_call.c
+++ b/src/video_call.c
@@ -41,13 +41,13 @@
 
 #define default_video_bit_rate 5000
 
-void receive_video_frame_cb(ToxAV *av, uint32_t friend_number,
+void on_video_receive_frame(ToxAV *av, uint32_t friend_number,
                             uint16_t width, uint16_t height,
                             uint8_t const *y, uint8_t const *u, uint8_t const *v,
                             int32_t ystride, int32_t ustride, int32_t vstride,
                             void *user_data);
 
-void video_bit_rate_status_cb(ToxAV *av, uint32_t friend_number, uint32_t video_bit_rate, void *user_data);
+void on_video_bit_rate(ToxAV *av, uint32_t friend_number, uint32_t video_bit_rate, void *user_data);
 
 static void print_err(ToxWindow *self, const char *error_str)
 {
@@ -74,8 +74,8 @@ ToxAV *init_video(ToxWindow *self, Tox *tox)
         return NULL;
     }
 
-    toxav_callback_video_receive_frame(CallControl.av, receive_video_frame_cb, &CallControl);
-    toxav_callback_video_bit_rate(CallControl.av, video_bit_rate_status_cb, &CallControl);
+    toxav_callback_video_receive_frame(CallControl.av, on_video_receive_frame, &CallControl);
+    toxav_callback_video_bit_rate(CallControl.av, on_video_bit_rate, &CallControl);
 
     return CallControl.av;
 }
@@ -179,7 +179,7 @@ int stop_video_transmission(Call *call, int friend_number)
 /*
  * Callbacks
  */
-void receive_video_frame_cb(ToxAV *av, uint32_t friend_number,
+void on_video_receive_frame(ToxAV *av, uint32_t friend_number,
                             uint16_t width, uint16_t height,
                             uint8_t const *y, uint8_t const *u, uint8_t const *v,
                             int32_t ystride, int32_t ustride, int32_t vstride,
@@ -188,7 +188,7 @@ void receive_video_frame_cb(ToxAV *av, uint32_t friend_number,
     write_video_device_callback(friend_number, width, height, y, u, v, ystride, ustride, vstride, user_data);
 }
 
-void video_bit_rate_status_cb(ToxAV *av, uint32_t friend_number, uint32_t video_bit_rate, void *user_data)
+void on_video_bit_rate(ToxAV *av, uint32_t friend_number, uint32_t video_bit_rate, void *user_data)
 {
     CallControl.video_bit_rate = video_bit_rate;
     toxav_video_set_bit_rate(CallControl.av, friend_number, CallControl.video_bit_rate, NULL);

--- a/src/windows.c
+++ b/src/windows.c
@@ -48,7 +48,7 @@ extern struct user_settings *user_settings;
 static int num_active_windows;
 
 /* CALLBACKS START */
-void on_request(Tox *m, const uint8_t *public_key, const uint8_t *data, size_t length, void *userdata)
+void on_friend_request(Tox *m, const uint8_t *public_key, const uint8_t *data, size_t length, void *userdata)
 {
     char msg[MAX_STR_SIZE + 1];
     length = copy_tox_str(msg, sizeof(msg), (const char *) data, length);
@@ -62,7 +62,7 @@ void on_request(Tox *m, const uint8_t *public_key, const uint8_t *data, size_t l
     }
 }
 
-void on_connectionchange(Tox *m, uint32_t friendnumber, TOX_CONNECTION connection_status, void *userdata)
+void on_friend_connection_status(Tox *m, uint32_t friendnumber, TOX_CONNECTION connection_status, void *userdata)
 {
     size_t i;
 
@@ -73,7 +73,7 @@ void on_connectionchange(Tox *m, uint32_t friendnumber, TOX_CONNECTION connectio
     }
 }
 
-void on_typing_change(Tox *m, uint32_t friendnumber, bool is_typing, void *userdata)
+void on_friend_typing(Tox *m, uint32_t friendnumber, bool is_typing, void *userdata)
 {
     if (user_settings->show_typing_other == SHOW_TYPING_OFF) {
         return;
@@ -88,8 +88,8 @@ void on_typing_change(Tox *m, uint32_t friendnumber, bool is_typing, void *userd
     }
 }
 
-void on_message(Tox *m, uint32_t friendnumber, TOX_MESSAGE_TYPE type, const uint8_t *string, size_t length,
-                void *userdata)
+void on_friend_message(Tox *m, uint32_t friendnumber, TOX_MESSAGE_TYPE type, const uint8_t *string, size_t length,
+                       void *userdata)
 {
     char msg[MAX_STR_SIZE + 1];
     length = copy_tox_str(msg, sizeof(msg), (const char *) string, length);
@@ -103,7 +103,7 @@ void on_message(Tox *m, uint32_t friendnumber, TOX_MESSAGE_TYPE type, const uint
     }
 }
 
-void on_nickchange(Tox *m, uint32_t friendnumber, const uint8_t *string, size_t length, void *userdata)
+void on_friend_name(Tox *m, uint32_t friendnumber, const uint8_t *string, size_t length, void *userdata)
 {
     char nick[TOXIC_MAX_NAME_LENGTH + 1];
     length = copy_tox_str(nick, sizeof(nick), (const char *) string, length);
@@ -120,7 +120,7 @@ void on_nickchange(Tox *m, uint32_t friendnumber, const uint8_t *string, size_t 
     store_data(m, DATA_FILE);
 }
 
-void on_statusmessagechange(Tox *m, uint32_t friendnumber, const uint8_t *string, size_t length, void *userdata)
+void on_friend_status_message(Tox *m, uint32_t friendnumber, const uint8_t *string, size_t length, void *userdata)
 {
     char msg[TOX_MAX_STATUS_MESSAGE_LENGTH + 1];
     length = copy_tox_str(msg, sizeof(msg), (const char *) string, length);
@@ -135,7 +135,7 @@ void on_statusmessagechange(Tox *m, uint32_t friendnumber, const uint8_t *string
     }
 }
 
-void on_statuschange(Tox *m, uint32_t friendnumber, TOX_USER_STATUS status, void *userdata)
+void on_friend_status(Tox *m, uint32_t friendnumber, TOX_USER_STATUS status, void *userdata)
 {
     size_t i;
 
@@ -146,7 +146,7 @@ void on_statuschange(Tox *m, uint32_t friendnumber, TOX_USER_STATUS status, void
     }
 }
 
-void on_friendadded(Tox *m, uint32_t friendnumber, bool sort)
+void on_friend_added(Tox *m, uint32_t friendnumber, bool sort)
 {
     size_t i;
 
@@ -159,8 +159,8 @@ void on_friendadded(Tox *m, uint32_t friendnumber, bool sort)
     store_data(m, DATA_FILE);
 }
 
-void on_groupmessage(Tox *m, uint32_t groupnumber, uint32_t peernumber, TOX_MESSAGE_TYPE type,
-                     const uint8_t *message, size_t length, void *userdata)
+void on_conference_message(Tox *m, uint32_t groupnumber, uint32_t peernumber, TOX_MESSAGE_TYPE type,
+                           const uint8_t *message, size_t length, void *userdata)
 {
     char msg[MAX_STR_SIZE + 1];
     length = copy_tox_str(msg, sizeof(msg), (const char *) message, length);
@@ -174,8 +174,8 @@ void on_groupmessage(Tox *m, uint32_t groupnumber, uint32_t peernumber, TOX_MESS
     }
 }
 
-void on_groupinvite(Tox *m, uint32_t friendnumber, TOX_CONFERENCE_TYPE type, const uint8_t *group_pub_key,
-                    size_t length, void *userdata)
+void on_conference_invite(Tox *m, uint32_t friendnumber, TOX_CONFERENCE_TYPE type, const uint8_t *group_pub_key,
+                          size_t length, void *userdata)
 {
     size_t i;
 
@@ -186,7 +186,7 @@ void on_groupinvite(Tox *m, uint32_t friendnumber, TOX_CONFERENCE_TYPE type, con
     }
 }
 
-void on_group_namelistchange(Tox *m, uint32_t groupnumber, void *userdata)
+void on_conference_peer_list_changed(Tox *m, uint32_t groupnumber, void *userdata)
 {
     size_t i;
 
@@ -197,7 +197,7 @@ void on_group_namelistchange(Tox *m, uint32_t groupnumber, void *userdata)
     }
 }
 
-void on_group_peernamechange(Tox *m, uint32_t groupnumber, uint32_t peernumber, const uint8_t *name,
+void on_conference_peer_name(Tox *m, uint32_t groupnumber, uint32_t peernumber, const uint8_t *name,
                              size_t length, void *userdata)
 {
     char nick[TOXIC_MAX_NAME_LENGTH + 1];
@@ -213,8 +213,8 @@ void on_group_peernamechange(Tox *m, uint32_t groupnumber, uint32_t peernumber, 
     }
 }
 
-void on_group_titlechange(Tox *m, uint32_t groupnumber, uint32_t peernumber, const uint8_t *title, size_t length,
-                          void *userdata)
+void on_conference_title(Tox *m, uint32_t groupnumber, uint32_t peernumber, const uint8_t *title, size_t length,
+                         void *userdata)
 {
     char data[MAX_STR_SIZE + 1];
     length = copy_tox_str(data, sizeof(data), (const char *) title, length);
@@ -269,8 +269,8 @@ void on_file_recv_chunk(Tox *m, uint32_t friendnumber, uint32_t filenumber, uint
     }
 }
 
-void on_file_control(Tox *m, uint32_t friendnumber, uint32_t filenumber, TOX_FILE_CONTROL control,
-                     void *userdata)
+void on_file_recv_control(Tox *m, uint32_t friendnumber, uint32_t filenumber, TOX_FILE_CONTROL control,
+                          void *userdata)
 {
     struct FileTransfer *ft = get_file_transfer_struct(friendnumber, filenumber);
 
@@ -311,7 +311,7 @@ void on_file_recv(Tox *m, uint32_t friendnumber, uint32_t filenumber, uint32_t k
     }
 }
 
-void on_read_receipt(Tox *m, uint32_t friendnumber, uint32_t receipt, void *userdata)
+void on_friend_read_receipt(Tox *m, uint32_t friendnumber, uint32_t receipt, void *userdata)
 {
     size_t i;
 


### PR DESCRIPTION
So it's easy to map from implementation to the event without looking at
the `tox_callback_*` calls.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxic/7)
<!-- Reviewable:end -->
