### PR TITLE
Use bazel import libs instead of global `-l` flags.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -10,17 +10,15 @@ cc_binary(
         "-DPYTHON",
         "-DVIDEO",
     ],
-    linkopts = [
-        "-lncurses",
-        "-lopenal",
-        "-lX11",
-    ],
     deps = [
         "//c-toxcore",
         "@curl",
         "@libconfig",
         "@libqrencode",
         "@libvpx",
+        "@ncurses",
+        "@openal",
         "@python3//:python",
+        "@x11//:X11",
     ],
 )


### PR DESCRIPTION
Import libs currently also point to the global system installed versions,
but at least we have the freedom to import them properly later.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxic/10)
<!-- Reviewable:end -->
