### PR TITLE
Add `_POSIX_C_SOURCE` to most .c files.

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -20,6 +20,10 @@
  *
  */
 
+#ifndef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <dirent.h>
 #include <stdint.h>
 

--- a/src/audio_call.c
+++ b/src/audio_call.c
@@ -20,6 +20,15 @@
  *
  */
 
+#ifndef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
+#endif
+
+#ifndef _DEFAULT_SOURCE
+// For strncasecmp.
+#define _DEFAULT_SOURCE
+#endif
+
 #include "toxic.h"
 #include "windows.h"
 #include "audio_call.h"

--- a/src/audio_device.c
+++ b/src/audio_device.c
@@ -20,6 +20,10 @@
  *
  */
 
+#ifndef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
+#endif
+
 #include "audio_device.h"
 
 #ifdef AUDIO
@@ -127,7 +131,10 @@ DeviceError terminate_devices()
     thread_running = false;
     unlock;
 
-    usleep(20000);
+    struct timespec twenty_seconds;
+    twenty_seconds.tv_sec = 20;
+    twenty_seconds.tv_nsec = 0;
+    nanosleep(&twenty_seconds, NULL);
 
     if (pthread_mutex_destroy(&mutex) != 0) {
         return (DeviceError) de_InternalError;
@@ -479,7 +486,10 @@ void *thread_poll(void *arg)  // TODO: maybe use thread for every input source
 
         /* Wait for unpause. */
         if (paused) {
-            usleep(10000);
+            struct timespec ten_seconds;
+            ten_seconds.tv_sec = 10;
+            ten_seconds.tv_nsec = 0;
+            nanosleep(&ten_seconds, NULL);
         }
 
         else {
@@ -514,7 +524,10 @@ void *thread_poll(void *arg)  // TODO: maybe use thread for every input source
                 unlock;
             }
 
-            usleep(5000);
+            struct timespec five_seconds;
+            five_seconds.tv_sec = 10;
+            five_seconds.tv_nsec = 0;
+            nanosleep(&five_seconds, NULL);
         }
     }
 

--- a/src/autocomplete.c
+++ b/src/autocomplete.c
@@ -20,6 +20,15 @@
  *
  */
 
+#ifndef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
+#endif
+
+#ifndef _DEFAULT_SOURCE
+// For strncasecmp.
+#define _DEFAULT_SOURCE
+#endif
+
 #include <stdlib.h>
 #include <string.h>
 #include <limits.h>

--- a/src/avatars.c
+++ b/src/avatars.c
@@ -20,6 +20,10 @@
  *
  */
 
+#ifndef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>

--- a/src/bootstrap.c
+++ b/src/bootstrap.c
@@ -20,6 +20,10 @@
  *
  */
 
+#ifndef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <stdlib.h>
 #include <string.h>
 #include <stdbool.h>

--- a/src/chat_commands.c
+++ b/src/chat_commands.c
@@ -20,6 +20,11 @@
  *
  */
 
+#ifndef _DEFAULT_SOURCE
+// For strncasecmp.
+#define _DEFAULT_SOURCE
+#endif
+
 #include <stdlib.h>
 #include <string.h>
 

--- a/src/configdir.c
+++ b/src/configdir.c
@@ -20,6 +20,10 @@
  *
  */
 
+#ifndef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>

--- a/src/execute.c
+++ b/src/execute.c
@@ -20,6 +20,10 @@
  *
  */
 
+#ifndef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>

--- a/src/file_transfers.c
+++ b/src/file_transfers.c
@@ -20,6 +20,10 @@
  *
  */
 
+#ifndef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <string.h>
 #include <stdlib.h>
 #include <time.h>

--- a/src/friendlist.c
+++ b/src/friendlist.c
@@ -20,6 +20,10 @@
  *
  */
 
+#ifndef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <string.h>
 #include <stdint.h>
 #include <stdlib.h>

--- a/src/global_commands.c
+++ b/src/global_commands.c
@@ -20,6 +20,15 @@
  *
  */
 
+#ifndef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
+#endif
+
+#ifndef _DEFAULT_SOURCE
+// For strcasecmp.
+#define _DEFAULT_SOURCE
+#endif
+
 #include <stdlib.h>
 #include <string.h>
 

--- a/src/group_commands.c
+++ b/src/group_commands.c
@@ -20,6 +20,10 @@
  *
  */
 
+#ifndef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <string.h>
 
 #include "toxic.h"

--- a/src/help.c
+++ b/src/help.c
@@ -20,6 +20,10 @@
  *
  */
 
+#ifndef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <string.h>
 
 #include "windows.h"

--- a/src/line_info.c
+++ b/src/line_info.c
@@ -20,6 +20,15 @@
  *
  */
 
+#ifndef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
+#endif
+
+#ifndef _DEFAULT_SOURCE
+// For strsep.
+#define _DEFAULT_SOURCE
+#endif
+
 #include <stdlib.h>
 #include <string.h>
 #include <stdbool.h>

--- a/src/log.c
+++ b/src/log.c
@@ -20,6 +20,10 @@
  *
  */
 
+#ifndef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>

--- a/src/message_queue.c
+++ b/src/message_queue.c
@@ -20,6 +20,10 @@
  *
  */
 
+#ifndef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <stdlib.h>
 
 #include "toxic.h"

--- a/src/misc_tools.c
+++ b/src/misc_tools.c
@@ -20,6 +20,15 @@
  *
  */
 
+#ifndef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
+#endif
+
+#ifndef _DEFAULT_SOURCE
+// For strncasecmp.
+#define _DEFAULT_SOURCE
+#endif
+
 #include <stdlib.h>
 #include <ctype.h>
 #include <string.h>

--- a/src/name_lookup.c
+++ b/src/name_lookup.c
@@ -20,6 +20,8 @@
  *
  */
 
+#define _DEFAULT_SOURCE  // For strcasecmp.
+
 #include <stdlib.h>
 #include <stdarg.h>
 #include <string.h>

--- a/src/notify.c
+++ b/src/notify.c
@@ -20,6 +20,10 @@
  *
  */
 
+#ifndef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>

--- a/src/settings.c
+++ b/src/settings.c
@@ -20,6 +20,15 @@
  *
  */
 
+#ifndef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
+#endif
+
+#ifndef _DEFAULT_SOURCE
+// For strncasecmp.
+#define _DEFAULT_SOURCE
+#endif
+
 #include <stdlib.h>
 #include <string.h>
 #include <libconfig.h>

--- a/src/term_mplex.c
+++ b/src/term_mplex.c
@@ -20,6 +20,10 @@
  *
  */
 
+#ifndef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <limits.h> /* PATH_MAX */
 #include <stdio.h>  /* fgets, popen, pclose */
 #include <stdlib.h> /* malloc, realloc, free, getenv */

--- a/src/toxic.c
+++ b/src/toxic.c
@@ -20,6 +20,14 @@
  *
  */
 
+#ifndef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
+#endif
+
+#ifndef _DEFAULT_SOURCE
+#define _DEFAULT_SOURCE
+#endif
+
 #include <curses.h>
 #include <errno.h>
 #include <stdio.h>
@@ -883,7 +891,10 @@ void *thread_cqueue(void *data)
 
         pthread_mutex_unlock(&Winthread.lock);
 
-        usleep(4000);
+        struct timespec pause;
+        pause.tv_sec = 4;
+        pause.tv_nsec = 0;
+        nanosleep(&pause, NULL);
     }
 }
 
@@ -897,7 +908,10 @@ void *thread_av(void *data)
         toxav_iterate(av);
         pthread_mutex_unlock(&Winthread.lock);
 
-        usleep(toxav_iteration_interval(av) * 1000);
+        struct timespec pause;
+        pause.tv_sec = 0;
+        pause.tv_nsec = toxav_iteration_interval(av) * 1000 * 1000;
+        nanosleep(&pause, NULL);
     }
 }
 #endif  /* AUDIO */
@@ -1377,7 +1391,10 @@ int main(int argc, char **argv)
             last_save = cur_time;
         }
 
-        usleep(tox_iteration_interval(m) * 1000);
+        struct timespec pause;
+        pause.tv_sec = 0;
+        pause.tv_nsec = tox_iteration_interval(m) * 1000 * 1000;
+        nanosleep(&pause, NULL);
     }
 
     return 0;

--- a/src/toxic_strings.c
+++ b/src/toxic_strings.c
@@ -20,6 +20,10 @@
  *
  */
 
+#ifndef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <stdlib.h>
 #include <string.h>
 #include <wchar.h>

--- a/src/video_call.c
+++ b/src/video_call.c
@@ -20,6 +20,11 @@
  *
  */
 
+#ifndef _DEFAULT_SOURCE
+// For strcasecmp.
+#define _DEFAULT_SOURCE
+#endif
+
 #include "toxic.h"
 #include "windows.h"
 #include "video_call.h"

--- a/src/video_device.c
+++ b/src/video_device.c
@@ -20,6 +20,10 @@
  *
  */
 
+#ifndef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
+#endif
+
 #include "video_device.h"
 #include "video_call.h"
 
@@ -257,7 +261,10 @@ VideoDeviceError terminate_video_devices()
     video_thread_running = false;
     unlock;
 
-    usleep(20000);
+    struct timespec twenty_seconds;
+    twenty_seconds.tv_sec = 20;
+    twenty_seconds.tv_nsec = 0;
+    nanosleep(&twenty_seconds, NULL);
 
     int i;
 
@@ -673,7 +680,11 @@ void *video_thread_poll(void *arg)  // TODO: maybe use thread for every input so
         unlock;
 
         if (video_thread_paused) {
-            usleep(10000);    /* Wait for unpause. */
+            struct timespec ten_seconds;
+            ten_seconds.tv_sec = 10;
+            ten_seconds.tv_nsec = 0;
+            /* Wait for unpause. */
+            nanosleep(&ten_seconds, NULL);
         } else {
             for (i = 0; i < size[vdt_input]; ++i) {
                 lock;
@@ -762,7 +773,10 @@ void *video_thread_poll(void *arg)  // TODO: maybe use thread for every input so
                 unlock;
             }
 
-            usleep(1000 * 1000 / 24);
+            struct timespec pause;
+            pause.tv_sec = 1000 / 24; // Why 41?
+            pause.tv_nsec = 0;
+            nanosleep(&pause, NULL);
         }
     }
 

--- a/src/windows.c
+++ b/src/windows.c
@@ -20,6 +20,10 @@
  *
  */
 
+#ifndef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <stdlib.h>
 #include <string.h>
 #include <pthread.h>

--- a/src/xtra.c
+++ b/src/xtra.c
@@ -20,6 +20,11 @@
  *
  */
 
+#ifndef _POSIX_C_SOURCE
+// For strtok_r.
+#define _POSIX_C_SOURCE 200809L
+#endif
+
 #include "xtra.h"
 
 #include <X11/Xlib.h>
@@ -243,7 +248,10 @@ void *event_loop(void *p)
 
         if (!pending) {
             XUnlockDisplay(Xtra.display);
-            usleep(10000);
+            struct timespec ten_seconds;
+            ten_seconds.tv_sec = 10;
+            ten_seconds.tv_nsec = 0;
+            nanosleep(&ten_seconds, NULL);
             continue;
         }
 


### PR DESCRIPTION
This is needed because .h files use definitions from POSIX and thus makes
all .c files that include them non-portable. In the future, we should
hide some of those platform-specific definitions in a .c file and access
them indirectly from portable business logic files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxic/15)
<!-- Reviewable:end -->
