### PR TITLE
Allow empty status messages

### DIFF
--- a/src/prompt.c
+++ b/src/prompt.c
@@ -494,7 +494,7 @@ static void prompt_onFriendRequest(ToxWindow *self, Tox *m, const char *key, con
     sound_notify(self, generic_message, NT_WNDALERT_1 | NT_NOTIFWND, NULL);
 }
 
-void prompt_init_statusbar(ToxWindow *self, Tox *m)
+void prompt_init_statusbar(ToxWindow *self, Tox *m, bool first_time_run)
 {
     int x2, y2;
     getmaxyx(self->window, y2, x2);
@@ -524,7 +524,7 @@ void prompt_init_statusbar(ToxWindow *self, Tox *m)
     nick[n_len] = '\0';
     statusmsg[s_len] = '\0';
 
-    if (s_len == 0 || !strncmp(statusmsg, "Toxing on Toxic", strlen("Toxing on Toxic"))) {
+    if (first_time_run) {
         snprintf(statusmsg, sizeof(statusmsg), "Toxing on Toxic");
         s_len = strlen(statusmsg);
         statusmsg[s_len] = '\0';

--- a/src/prompt.h
+++ b/src/prompt.h
@@ -45,7 +45,7 @@ extern FriendRequests FrndRequests;
 ToxWindow new_prompt(void);
 
 void prep_prompt_win(void);
-void prompt_init_statusbar(ToxWindow *self, Tox *m);
+void prompt_init_statusbar(ToxWindow *self, Tox *m, bool first_time_run);
 void prompt_update_nick(ToxWindow *prompt, const char *nick);
 void prompt_update_statusmessage(ToxWindow *prompt, Tox *m, const char *statusmsg);
 void prompt_update_status(ToxWindow *prompt, TOX_USER_STATUS status);

--- a/src/toxic.c
+++ b/src/toxic.c
@@ -1285,7 +1285,7 @@ int main(int argc, char **argv)
     init_term();
 
     prompt = init_windows(m);
-    prompt_init_statusbar(prompt, m);
+    prompt_init_statusbar(prompt, m, !datafile_exists);
     load_groups(prompt, m);
 
     /* thread for ncurses stuff */


### PR DESCRIPTION
This change prevents toxic from forcing the default status message when it's otherwise empty, with the exception of new profiles. In other words, users can now set a blank status message.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxic/30)
<!-- Reviewable:end -->
