### PR TITLE
Remove requirement for argument strings and paths to be enclosed in quotes for all commands

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -151,9 +151,9 @@ void cmd_run(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[MAX
 
     if (argc != 1) {
         if (argc < 1) {
-            error_str = "Path must be specified!";
+            error_str = "Path must be specified.";
         } else {
-            error_str = "Only one argument allowed!";
+            error_str = "Only one argument allowed.";
         }
 
         line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, error_str);
@@ -163,7 +163,7 @@ void cmd_run(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[MAX
     fp = fopen(argv[1], "r");
 
     if (fp == NULL) {
-        error_str = "Path does not exist!";
+        error_str = "Path does not exist.";
 
         line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, error_str);
         return;

--- a/src/api.h
+++ b/src/api.h
@@ -38,5 +38,6 @@ int num_registered_handlers(void);
 int help_max_width(void);
 void draw_handler_help(WINDOW *win);
 void invoke_autoruns(WINDOW *w, ToxWindow *self);
+void cmd_run(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[MAX_STR_SIZE]);
 
 #endif /* API_H */

--- a/src/autocomplete.c
+++ b/src/autocomplete.c
@@ -107,10 +107,9 @@ int complete_line(ToxWindow *self, const void *list, size_t n_items, size_t size
         return -1;
     }
 
-    const char *L = (char *) list;
+    const char *L = (const char *) list;
     const char *endchrs = " ";
-    char ubuf[MAX_STR_SIZE];
-    memset(ubuf, 0, sizeof(ubuf));
+    char ubuf[MAX_STR_SIZE] = {0};
 
     /* work with multibyte string copy of buf for simplicity */
     if (wcs_to_mbs_buf(ubuf, ctx->line, sizeof(ubuf)) == -1) {

--- a/src/autocomplete.c
+++ b/src/autocomplete.c
@@ -99,7 +99,11 @@ int complete_line(ToxWindow *self, const void *list, size_t n_items, size_t size
 {
     ChatContext *ctx = self->chatwin;
 
-    if (ctx->pos <= 0 || ctx->len <= 0 || ctx->pos > ctx->len || ctx->len >= MAX_STR_SIZE || size > MAX_STR_SIZE) {
+    if (ctx->pos <= 0 || ctx->len <= 0 || ctx->pos > ctx->len) {
+        return -1;
+    }
+
+    if (ctx->len >= MAX_STR_SIZE || size > MAX_STR_SIZE) {
         return -1;
     }
 

--- a/src/autocomplete.h
+++ b/src/autocomplete.h
@@ -23,20 +23,25 @@
 #ifndef AUTOCOMPLETE_H
 #define AUTOCOMPLETE_H
 
-/* looks for all instances in list that begin with the last entered word in line according to pos,
-   then fills line with the complete word. e.g. "Hello jo" would complete the line
-   with "Hello john". If multiple matches, prints out all the matches and semi-completes line.
-
-   list is a pointer to the list of strings being compared, n_items is the number of items
-   in the list, and size is the size of each item in the list.
-
-   Returns the difference between the old len and new len of line on success, -1 if error */
+/*
+ * Looks for all instances in list that begin with the last entered word in line according to pos,
+ * then fills line with the complete word. e.g. "Hello jo" would complete the line
+ * with "Hello john". If multiple matches, prints out all the matches and semi-completes line.
+ *
+ * list is a pointer to the list of strings being compared, n_items is the number of items
+ * in the list, and size is the size of each item in the list.
+ *
+ * Returns the difference between the old len and new len of line on success.
+ * Returns -1 on error.
+ */
 int complete_line(ToxWindow *self, const void *list, size_t n_items, size_t size);
 
-/*  attempts to match /command "<incomplete-dir>" line to matching directories.
-
-    if only one match, auto-complete line.
-    return diff between old len and new len of ctx->line, -1 if no matches or > 1 match */
+/* Attempts to match /command "<incomplete-dir>" line to matching directories.
+ * If there is only one match the line is auto-completed.
+ *
+ * Returns the diff between old len and new len of ctx->line on success.
+ * Returns -1 if no matches or more than one match.
+ */
 int dir_match(ToxWindow *self, Tox *m, const wchar_t *line, const wchar_t *cmd);
 
 #endif /* AUTOCOMPLETE_H */

--- a/src/chat.c
+++ b/src/chat.c
@@ -1005,14 +1005,14 @@ static void chat_onKey(ToxWindow *self, Tox *m, wint_t key, bool ltr)
         int diff = -1;
 
         /* TODO: make this not suck */
-        if (wcsncmp(ctx->line, L"/sendfile \"", wcslen(L"/sendfile \"")) == 0) {
+        if (wcsncmp(ctx->line, L"/sendfile ", wcslen(L"/sendfile ")) == 0) {
             diff = dir_match(self, m, ctx->line, L"/sendfile");
-        } else if (wcsncmp(ctx->line, L"/avatar \"", wcslen(L"/avatar \"")) == 0) {
+        } else if (wcsncmp(ctx->line, L"/avatar ", wcslen(L"/avatar ")) == 0) {
             diff = dir_match(self, m, ctx->line, L"/avatar");
         }
 
 #ifdef PYTHON
-        else if (wcsncmp(ctx->line, L"/run \"", wcslen(L"/run \"")) == 0) {
+        else if (wcsncmp(ctx->line, L"/run ", wcslen(L"/run ")) == 0) {
             diff = dir_match(self, m, ctx->line, L"/run");
         }
 

--- a/src/chat_commands.c
+++ b/src/chat_commands.c
@@ -167,7 +167,7 @@ void cmd_savefile(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv
     }
 
     if ((ft->file = fopen(ft->file_path, "a")) == NULL) {
-        const char *msg =  "File transfer failed: Invalid file path.";
+        const char *msg =  "File transfer failed: Invalid download path.";
         close_file_transfer(self, m, ft, TOX_FILE_CONTROL_CANCEL, msg, notif_error);
         return;
     }
@@ -225,16 +225,9 @@ void cmd_sendfile(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv
         return;
     }
 
-    if (argv[1][0] != '\"') {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "File path must be enclosed in quotes.");
-        return;
-    }
-
-    /* remove opening and closing quotes */
     char path[MAX_STR_SIZE];
-    snprintf(path, sizeof(path), "%s", &argv[1][1]);
-    int path_len = strlen(path) - 1;
-    path[path_len] = '\0';
+    snprintf(path, sizeof(path), "%s", argv[1]);
+    int path_len = strlen(path);
 
     if (path_len >= MAX_STR_SIZE) {
         line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "File path exceeds character limit.");

--- a/src/execute.c
+++ b/src/execute.c
@@ -107,10 +107,60 @@ static struct cmd_func group_commands[] = {
     { NULL,         NULL            },
 };
 
+/* Special commands are commands that only take one argument even if it contains spaces */
+#define SPECIAL_COMMANDS 3
+static const char special_commands[SPECIAL_COMMANDS][MAX_CMDNAME_SIZE] = {
+    "/nick",
+    "/note",
+    "/title",
+};
+
+/* Returns true if input command is in the special_commands array. */
+static bool is_special_command(const char *input)
+{
+    int start = char_find(0, input, ' ');
+
+    int i;
+
+    for (i = 0; i < SPECIAL_COMMANDS; ++i) {
+        if (strncmp(input, special_commands[i], start) == 0) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/* Parses commands in the special_commands array. Unlike parse_command, this function
+ * does not split the input string at spaces.
+ *
+ * Returns number of arguments on success, returns -1 on failure
+ */
+static int parse_special_command(WINDOW *w, ToxWindow *self, const char *input, char (*args)[MAX_STR_SIZE])
+{
+    int len = strlen(input);
+    int s = char_find(0, input, ' ');
+
+    if (s + 1 >= len) {
+        return -1;
+    }
+
+    memcpy(args[0], input, s);
+    args[0][s++] = '\0';    /* increment to remove space after /command */
+    memcpy(args[1], input + s, len - s);
+    args[1][len - s] = '\0';
+
+    return 2;
+}
+
 /* Parses input command and puts args into arg array.
    Returns number of arguments on success, -1 on failure. */
 static int parse_command(WINDOW *w, ToxWindow *self, const char *input, char (*args)[MAX_STR_SIZE])
 {
+    if (is_special_command(input)) {
+        return parse_special_command(w, self, input, args);
+    }
+
     char *cmd = strdup(input);
 
     if (cmd == NULL) {

--- a/src/execute.c
+++ b/src/execute.c
@@ -129,10 +129,9 @@ static const char special_commands[SPECIAL_COMMANDS][MAX_CMDNAME_SIZE] = {
 /* Returns true if input command is in the special_commands array. */
 static bool is_special_command(const char *input)
 {
-    int s = char_find(0, input, ' ');
-    int i;
+    const int s = char_find(0, input, ' ');
 
-    for (i = 0; i < SPECIAL_COMMANDS; ++i) {
+    for (int i = 0; i < SPECIAL_COMMANDS; ++i) {
         if (strncmp(input, special_commands[i], s) == 0) {
             return true;
         }

--- a/src/execute.c
+++ b/src/execute.c
@@ -181,11 +181,10 @@ static int parse_command(WINDOW *w, ToxWindow *self, const char *input, char (*a
     }
 
     int num_args = 0;
-    int i = 0;    // index of last char in an argument
 
     /* characters wrapped in double quotes count as one arg */
     while (num_args < MAX_NUM_ARGS) {
-        i = char_find(0, cmd, ' ');
+        int i = char_find(0, cmd, ' ');    // index of last char in an argument
         memcpy(args[num_args], cmd, i);
         args[num_args++][i] = '\0';
 

--- a/src/global_commands.c
+++ b/src/global_commands.c
@@ -201,21 +201,15 @@ void cmd_add(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[MAX
 
 void cmd_avatar(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[MAX_STR_SIZE])
 {
-    if (argc < 2 || strlen(argv[1]) < 3) {
+    if (argc != 1 || strlen(argv[1]) < 3) {
         avatar_unset(m);
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Avatar is not set.");
+        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Avatar has been unset.");
         return;
     }
 
-    if (argv[1][0] != '\"') {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Path must be enclosed in quotes.");
-        return;
-    }
-
-    /* remove opening and closing quotes */
     char path[MAX_STR_SIZE];
-    snprintf(path, sizeof(path), "%s", &argv[1][1]);
-    int len = strlen(path) - 1;
+    snprintf(path, sizeof(path), "%s", argv[1]);
+    int len = strlen(path);
 
     if (len <= 0) {
         line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Invalid path.");
@@ -502,16 +496,8 @@ void cmd_nick(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[MA
     }
 
     char nick[MAX_STR_SIZE];
-    size_t len = 0;
-
-    if (argv[1][0] == '\"') {    /* remove opening and closing quotes */
-        snprintf(nick, sizeof(nick), "%s", &argv[1][1]);
-        len = strlen(nick) - 1;
-        nick[len] = '\0';
-    } else {
-        snprintf(nick, sizeof(nick), "%s", argv[1]);
-        len = strlen(nick);
-    }
+    snprintf(nick, sizeof(nick), "%s", argv[1]);
+    size_t len = strlen(nick);
 
     if (!valid_nick(nick)) {
         line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Invalid name.");

--- a/src/global_commands.c
+++ b/src/global_commands.c
@@ -534,19 +534,7 @@ void cmd_note(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[MA
         return;
     }
 
-    if (argv[1][0] != '\"') {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Note must be enclosed in quotes.");
-        return;
-    }
-
-    /* remove opening and closing quotes and replace linebreaks with spaces */
-    char msg[MAX_STR_SIZE];
-    snprintf(msg, sizeof(msg), "%s", &argv[1][1]);
-    int len = strlen(msg) - 1;
-    msg[len] = '\0';
-    strsubst(msg, '\n', ' ');
-
-    prompt_update_statusmessage(prompt, m, msg);
+    prompt_update_statusmessage(prompt, m, argv[1]);
 }
 
 void cmd_nospam(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[MAX_STR_SIZE])

--- a/src/global_commands.c
+++ b/src/global_commands.c
@@ -592,14 +592,11 @@ void cmd_requests(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv
 
 void cmd_status(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[MAX_STR_SIZE])
 {
-    bool have_note = false;
     const char *errmsg;
 
     lock_status();
 
-    if (argc >= 2) {
-        have_note = true;
-    } else if (argc < 1) {
+    if (argc < 1) {
         errmsg = "Require a status. Statuses are: online, busy and away.";
         line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, errmsg);
         goto finish;
@@ -622,24 +619,8 @@ void cmd_status(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[
 
     tox_self_set_status(m, status);
     prompt_update_status(prompt, status);
+    line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Your status has been changed to %s.", status_str);
 
-    if (have_note) {
-        if (argv[2][0] != '\"') {
-            line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Note must be enclosed in quotes.");
-            goto finish;
-        }
-
-        /* remove opening and closing quotes */
-        char msg[MAX_STR_SIZE];
-        snprintf(msg, sizeof(msg), "%s", &argv[2][1]);
-        int len = strlen(msg) - 1;
-        msg[len] = '\0';
-
-        prompt_update_statusmessage(prompt, m, msg);
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Your status has been changed to %s: \"%s\".", status_str, msg);
-    } else {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Your status has been changed to %s.", status_str);
-    }
 
 finish:
     unlock_status();

--- a/src/group_commands.c
+++ b/src/group_commands.c
@@ -52,15 +52,8 @@ void cmd_set_title(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*arg
         return;
     }
 
-    if (argv[1][0] != '\"') {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Title must be enclosed in quotes.");
-        return;
-    }
-
-    /* remove opening and closing quotes */
-    snprintf(title, sizeof(title), "%s", &argv[1][1]);
-    int len = strlen(title) - 1;
-    title[len] = '\0';
+    snprintf(title, sizeof(title), "%s", argv[1]);
+    int len = strlen(title);
 
     if (!tox_conference_set_title(m, self->num, (uint8_t *) title, len, &err)) {
         line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Failed to set title (error %d)", err);

--- a/src/groupchat.c
+++ b/src/groupchat.c
@@ -512,7 +512,7 @@ static void groupchat_onKey(ToxWindow *self, Tox *m, wint_t key, bool ltr)
             }
 
 #ifdef PYTHON
-            else if (wcsncmp(ctx->line, L"/run \"", wcslen(L"/run ")) == 0) {
+            else if (wcsncmp(ctx->line, L"/run ", wcslen(L"/run ")) == 0) {
                 diff = dir_match(self, m, ctx->line, L"/run");
             }
 

--- a/src/groupchat.c
+++ b/src/groupchat.c
@@ -507,12 +507,12 @@ static void groupchat_onKey(ToxWindow *self, Tox *m, wint_t key, bool ltr)
             if (ctx->line[0] != L'/' || wcscmp(ctx->line, L"/me") == 0) {
                 diff = complete_line(self, groupchats[self->num].name_list, groupchats[self->num].num_peers,
                                      TOX_MAX_NAME_LENGTH);
-            } else if (wcsncmp(ctx->line, L"/avatar \"", wcslen(L"/avatar \"")) == 0) {
+            } else if (wcsncmp(ctx->line, L"/avatar ", wcslen(L"/avatar ")) == 0) {
                 diff = dir_match(self, m, ctx->line, L"/avatar");
             }
 
 #ifdef PYTHON
-            else if (wcsncmp(ctx->line, L"/run \"", wcslen(L"/run \"")) == 0) {
+            else if (wcsncmp(ctx->line, L"/run \"", wcslen(L"/run ")) == 0) {
                 diff = dir_match(self, m, ctx->line, L"/run");
             }
 

--- a/src/misc_tools.c
+++ b/src/misc_tools.c
@@ -481,6 +481,25 @@ bool file_exists(const char *path)
     return stat(path, &s) == 0;
 }
 
+/* Returns 0 if path points to a directory.
+ * Returns 1 if path points to a regular file.
+ * Returns -1 on any other result.
+ */
+int file_type(const char *path)
+{
+    struct stat s;
+    stat(path, &s);
+
+    switch (s.st_mode & S_IFMT) {
+        case S_IFDIR:
+            return 0;
+        case S_IFREG:
+            return 1;
+        default:
+            return -1;
+   }
+}
+
 /* returns file size. If file doesn't exist returns 0. */
 off_t file_size(const char *path)
 {

--- a/src/misc_tools.c
+++ b/src/misc_tools.c
@@ -481,22 +481,25 @@ bool file_exists(const char *path)
     return stat(path, &s) == 0;
 }
 
-/* Returns 0 if path points to a directory.
- * Returns 1 if path points to a regular file.
- * Returns -1 on any other result.
+/*
+ * Checks the file type path points to and returns a File_Type enum value.
+ *
+ * Returns FILE_TYPE_DIRECTORY if path points to a directory.
+ * Returns FILE_TYPE_REGULAR if path points to a regular file.
+ * Returns FILE_TYPE_OTHER on any other result, including an invalid path.
  */
-int file_type(const char *path)
+File_Type file_type(const char *path)
 {
     struct stat s;
     stat(path, &s);
 
     switch (s.st_mode & S_IFMT) {
         case S_IFDIR:
-            return 0;
+            return FILE_TYPE_DIRECTORY;
         case S_IFREG:
-            return 1;
+            return FILE_TYPE_REGULAR;
         default:
-            return -1;
+            return FILE_TYPE_OTHER;
    }
 }
 

--- a/src/misc_tools.h
+++ b/src/misc_tools.h
@@ -86,13 +86,13 @@ int string_is_empty(const char *string);
 /* Same as above but for wide character strings */
 int wstring_is_empty(const wchar_t *string);
 
-/* convert a multibyte string to a wide character string (must provide buffer) */
+/* converts a multibyte string to a wide character string (must provide buffer) */
 int char_to_wcs_buf(wchar_t *buf, const char *string, size_t n);
 
 /* converts wide character string into a multibyte string and puts in buf. */
 int wcs_to_mbs_buf(char *buf, const wchar_t *string, size_t n);
 
-/* convert a multibyte string to a wide character string and puts in buf) */
+/* converts a multibyte string to a wide character string and puts in buf) */
 int mbs_to_wcs_buf(wchar_t *buf, const char *string, size_t n);
 
 /* Returns 1 if connection has timed out, 0 otherwise */

--- a/src/misc_tools.h
+++ b/src/misc_tools.h
@@ -39,6 +39,14 @@
 #define net_to_host(x, y) hst_to_net(x, y)
 #endif
 
+typedef enum File_Type
+{
+   FILE_TYPE_REGULAR,
+   FILE_TYPE_DIRECTORY,
+   FILE_TYPE_OTHER,
+} File_Type;
+
+
 void hst_to_net(uint8_t *num, uint16_t numbytes);
 
 /*
@@ -146,11 +154,14 @@ void bytes_convert_str(char *buf, int size, uint64_t bytes);
 /* checks if a file exists. Returns true or false */
 bool file_exists(const char *path);
 
-/* Returns 0 if path points to a directory.
- * Returns 1 if path points to a regular file.
- * Returns -1 on any other result.
+/*
+ * Checks the file type path points to and returns a File_Type enum value.
+ *
+ * Returns FILE_TYPE_DIRECTORY if path points to a directory.
+ * Returns FILE_TYPE_REGULAR if path points to a regular file.
+ * Returns FILE_TYPE_OTHER on any other result, including an invalid path.
  */
-int file_type(const char *path);
+File_Type file_type(const char *path);
 
 /* returns file size. If file doesn't exist returns 0. */
 off_t file_size(const char *path);

--- a/src/misc_tools.h
+++ b/src/misc_tools.h
@@ -146,6 +146,12 @@ void bytes_convert_str(char *buf, int size, uint64_t bytes);
 /* checks if a file exists. Returns true or false */
 bool file_exists(const char *path);
 
+/* Returns 0 if path points to a directory.
+ * Returns 1 if path points to a regular file.
+ * Returns -1 on any other result.
+ */
+int file_type(const char *path);
+
 /* returns file size. If file doesn't exist returns 0. */
 off_t file_size(const char *path);
 

--- a/src/prompt.c
+++ b/src/prompt.c
@@ -247,12 +247,12 @@ static void prompt_onKey(ToxWindow *self, Tox *m, wint_t key, bool ltr)
         if (ctx->len > 1 && ctx->line[0] == '/') {
             int diff = -1;
 
-            if (wcsncmp(ctx->line, L"/avatar \"", wcslen(L"/avatar \"")) == 0) {
+            if (wcsncmp(ctx->line, L"/avatar ", wcslen(L"/avatar ")) == 0) {
                 diff = dir_match(self, m, ctx->line, L"/avatar");
             }
 
 #ifdef PYTHON
-            else if (wcsncmp(ctx->line, L"/run \"", wcslen(L"/run \"")) == 0) {
+            else if (wcsncmp(ctx->line, L"/run ", wcslen(L"/run ")) == 0) {
                 diff = dir_match(self, m, ctx->line, L"/run");
             }
 

--- a/src/term_mplex.c
+++ b/src/term_mplex.c
@@ -33,7 +33,7 @@
 
 #include <tox/tox.h>
 
-#include "global_commands.h"
+#include "execute.h"
 #include "windows.h"
 #include "term_mplex.h"
 #include "toxic.h"
@@ -390,15 +390,16 @@ static void mplex_timer_handler(Tox *m)
         return;
     }
 
-    char argv[3][MAX_STR_SIZE];
-    strcpy(argv[0], "/status");
-    strcpy(argv[1], (new_status == TOX_USER_STATUS_AWAY ? "away" :
-                     new_status == TOX_USER_STATUS_BUSY ? "busy" : "online"));
-    argv[2][0] = '\"';
-    strcpy(argv[2] + 1, new_note);
-    strcat(argv[2], "\"");
+    char status_str[MAX_STR_SIZE];
+    char note_str[MAX_STR_SIZE];
+    const char *status = new_status == TOX_USER_STATUS_AWAY ? "away" :
+                    new_status == TOX_USER_STATUS_BUSY ? "busy" : "online";
+    snprintf(status_str, sizeof(status_str), "/status %s", status);
+    snprintf(note_str, sizeof(status_str), "/note %s", new_note);
+
     pthread_mutex_lock(&Winthread.lock);
-    cmd_status(prompt->chatwin->history, prompt, m, 2, argv);
+    execute(prompt->chatwin->history, prompt, m, status_str, GLOBAL_COMMAND_MODE);
+    execute(prompt->chatwin->history, prompt, m, note_str, GLOBAL_COMMAND_MODE);
     pthread_mutex_unlock(&Winthread.lock);
 }
 

--- a/src/toxic.c
+++ b/src/toxic.c
@@ -1355,7 +1355,7 @@ int main(int argc, char **argv)
 
     /* set user avatar from config file. if no path is supplied tox_unset_avatar is called */
     char avatarstr[PATH_MAX + 11];
-    snprintf(avatarstr, sizeof(avatarstr), "/avatar \"%s\"", user_settings->avatar_path);
+    snprintf(avatarstr, sizeof(avatarstr), "/avatar %s", user_settings->avatar_path);
     execute(prompt->chatwin->history, prompt, m, avatarstr, GLOBAL_COMMAND_MODE);
 
     time_t last_save = get_unix_time();


### PR DESCRIPTION
In addition, I removed the ability for the `status` command to double as the `note` command because it's an unnecessary special case that causes complications.

(Note: The file_type() function was added for future use)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxic/31)
<!-- Reviewable:end -->
