### PR TITLE
ToxWindow refactor

### DIFF
--- a/src/audio_call.c
+++ b/src/audio_call.c
@@ -58,6 +58,8 @@
 #endif /* __APPLE__ */
 
 extern FriendsList Friends;
+extern ToxWindow *windows[MAX_WINDOWS_NUM];
+
 struct CallControl CallControl;
 
 #define cbend pthread_exit(NULL)
@@ -371,38 +373,28 @@ void callback_recv_invite(Tox *m, uint32_t friend_number)
         Friends.list[friend_number].chatwin = add_window(m, new_chat(m, Friends.list[friend_number].num));
     }
 
-    ToxWindow *windows = CallControl.prompt;
-    int i;
-
-    for (i = 0; i < MAX_WINDOWS_NUM; ++i) {
-        if (windows[i].onInvite != NULL && windows[i].num == friend_number) {
-            windows[i].onInvite(&windows[i], CallControl.av, friend_number, CallControl.call_state);
+    for (uint8_t i = 0; i < MAX_WINDOWS_NUM; ++i) {
+        if (windows[i] != NULL && windows[i]->onInvite != NULL && windows[i]->num == friend_number) {
+            windows[i]->onInvite(windows[i], CallControl.av, friend_number, CallControl.call_state);
         }
     }
 }
 void callback_recv_ringing(uint32_t friend_number)
 {
-    ToxWindow *windows = CallControl.prompt;
-    int i;
-
-    for (i = 0; i < MAX_WINDOWS_NUM; ++i) {
-        if (windows[i].onRinging != NULL && windows[i].num == friend_number) {
-            windows[i].onRinging(&windows[i], CallControl.av, friend_number, CallControl.call_state);
+    for (uint8_t i = 0; i < MAX_WINDOWS_NUM; ++i) {
+        if (windows[i] != NULL && windows[i]->onRinging != NULL && windows[i]->num == friend_number) {
+            windows[i]->onRinging(windows[i], CallControl.av, friend_number, CallControl.call_state);
         }
     }
 }
 void callback_recv_starting(uint32_t friend_number)
 {
-    ToxWindow *windows = CallControl.prompt;
+    for (uint8_t i = 0; i < MAX_WINDOWS_NUM; ++i) {
+        if (windows[i] != NULL && windows[i]->onStarting != NULL && windows[i]->num == friend_number) {
+            windows[i]->onStarting(windows[i], CallControl.av, friend_number, CallControl.call_state);
 
-    int i;
-
-    for (i = 0; i < MAX_WINDOWS_NUM; ++i) {
-        if (windows[i].onStarting != NULL && windows[i].num == friend_number) {
-            windows[i].onStarting(&windows[i], CallControl.av, friend_number, CallControl.call_state);
-
-            if (0 != start_transmission(&windows[i], &CallControl.calls[friend_number])) { /* YEAH! */
-                line_info_add(&windows[i], NULL, NULL, NULL, SYS_MSG, 0, 0, "Error starting transmission!");
+            if (0 != start_transmission(windows[i], &CallControl.calls[friend_number])) { /* YEAH! */
+                line_info_add(windows[i], NULL, NULL, NULL, SYS_MSG, 0, 0, "Error starting transmission!");
             }
 
             return;
@@ -411,61 +403,46 @@ void callback_recv_starting(uint32_t friend_number)
 }
 void callback_recv_ending(uint32_t friend_number)
 {
-    ToxWindow *windows = CallControl.prompt;
-    int i;
-
-    for (i = 0; i < MAX_WINDOWS_NUM; ++i) {
-        if (windows[i].onEnding != NULL && windows[i].num == friend_number) {
-            windows[i].onEnding(&windows[i], CallControl.av, friend_number, CallControl.call_state);
+    for (uint8_t i = 0; i < MAX_WINDOWS_NUM; ++i) {
+        if (windows[i] != NULL && windows[i]->onEnding != NULL && windows[i]->num == friend_number) {
+            windows[i]->onEnding(windows[i], CallControl.av, friend_number, CallControl.call_state);
         }
     }
 }
 void callback_call_started(uint32_t friend_number)
 {
-    ToxWindow *windows = CallControl.prompt;
+    for (uint8_t i = 0; i < MAX_WINDOWS_NUM; ++i) {
+        if (windows[i] != NULL && windows[i]->onStart != NULL && windows[i]->num == friend_number) {
+            windows[i]->onStart(windows[i], CallControl.av, friend_number, CallControl.call_state);
 
-    int i;
-
-    for (i = 0; i < MAX_WINDOWS_NUM; ++i)
-        if (windows[i].onStart != NULL && windows[i].num == friend_number) {
-            windows[i].onStart(&windows[i], CallControl.av, friend_number, CallControl.call_state);
-
-            if (0 != start_transmission(&windows[i], &CallControl.calls[friend_number])) {  /* YEAH! */
-                line_info_add(&windows[i], NULL, NULL, NULL, SYS_MSG, 0, 0, "Error starting transmission!");
+            if (0 != start_transmission(windows[i], &CallControl.calls[friend_number])) {  /* YEAH! */
+                line_info_add(windows[i], NULL, NULL, NULL, SYS_MSG, 0, 0, "Error starting transmission!");
                 return;
             }
         }
+    }
 }
 void callback_call_canceled(uint32_t friend_number)
 {
-    ToxWindow *windows = CallControl.prompt;
-    int i;
-
-    for (i = 0; i < MAX_WINDOWS_NUM; ++i) {
-        if (windows[i].onCancel != NULL && windows[i].num == friend_number) {
-            windows[i].onCancel(&windows[i], CallControl.av, friend_number, CallControl.call_state);
+    for (uint8_t i = 0; i < MAX_WINDOWS_NUM; ++i) {
+        if (windows[i] != NULL && windows[i]->onCancel != NULL && windows[i]->num == friend_number) {
+            windows[i]->onCancel(windows[i], CallControl.av, friend_number, CallControl.call_state);
         }
     }
 }
 void callback_call_rejected(uint32_t friend_number)
 {
-    ToxWindow *windows = CallControl.prompt;
-    int i;
-
-    for (i = 0; i < MAX_WINDOWS_NUM; ++i) {
-        if (windows[i].onReject != NULL && windows[i].num == friend_number) {
-            windows[i].onReject(&windows[i], CallControl.av, friend_number, CallControl.call_state);
+    for (uint8_t i = 0; i < MAX_WINDOWS_NUM; ++i) {
+        if (windows[i] != NULL && windows[i]->onReject != NULL && windows[i]->num == friend_number) {
+            windows[i]->onReject(windows[i], CallControl.av, friend_number, CallControl.call_state);
         }
     }
 }
 void callback_call_ended(uint32_t friend_number)
 {
-    ToxWindow *windows = CallControl.prompt;
-    int i;
-
-    for (i = 0; i < MAX_WINDOWS_NUM; ++i) {
-        if (windows[i].onEnd != NULL && windows[i].num == friend_number) {
-            windows[i].onEnd(&windows[i], CallControl.av, friend_number, CallControl.call_state);
+    for (uint8_t i = 0; i < MAX_WINDOWS_NUM; ++i) {
+        if (windows[i] != NULL && windows[i]->onEnd != NULL && windows[i]->num == friend_number) {
+            windows[i]->onEnd(windows[i], CallControl.av, friend_number, CallControl.call_state);
         }
     }
 }

--- a/src/chat.c
+++ b/src/chat.c
@@ -1290,51 +1290,53 @@ static void chat_onInit(ToxWindow *self, Tox *m)
     wmove(self->window, y2 - CURS_Y_OFFSET, 0);
 }
 
-ToxWindow new_chat(Tox *m, uint32_t friendnum)
+ToxWindow *new_chat(Tox *m, uint32_t friendnum)
 {
-    ToxWindow ret;
-    memset(&ret, 0, sizeof(ret));
+    ToxWindow *ret = calloc(1, sizeof(ToxWindow));
 
-    ret.active = true;
-    ret.is_chat = true;
+    if (ret == NULL) {
+        exit_toxic_err("failed in new_chat", FATALERR_MEMORY);
+    }
 
-    ret.onKey = &chat_onKey;
-    ret.onDraw = &chat_onDraw;
-    ret.onInit = &chat_onInit;
-    ret.onMessage = &chat_onMessage;
-    ret.onConnectionChange = &chat_onConnectionChange;
-    ret.onTypingChange = & chat_onTypingChange;
-    ret.onGroupInvite = &chat_onGroupInvite;
-    ret.onNickChange = &chat_onNickChange;
-    ret.onStatusChange = &chat_onStatusChange;
-    ret.onStatusMessageChange = &chat_onStatusMessageChange;
-    ret.onFileChunkRequest = &chat_onFileChunkRequest;
-    ret.onFileRecvChunk = &chat_onFileRecvChunk;
-    ret.onFileControl = &chat_onFileControl;
-    ret.onFileRecv = &chat_onFileRecv;
-    ret.onReadReceipt = &chat_onReadReceipt;
+    ret->is_chat = true;
+
+    ret->onKey = &chat_onKey;
+    ret->onDraw = &chat_onDraw;
+    ret->onInit = &chat_onInit;
+    ret->onMessage = &chat_onMessage;
+    ret->onConnectionChange = &chat_onConnectionChange;
+    ret->onTypingChange = & chat_onTypingChange;
+    ret->onGroupInvite = &chat_onGroupInvite;
+    ret->onNickChange = &chat_onNickChange;
+    ret->onStatusChange = &chat_onStatusChange;
+    ret->onStatusMessageChange = &chat_onStatusMessageChange;
+    ret->onFileChunkRequest = &chat_onFileChunkRequest;
+    ret->onFileRecvChunk = &chat_onFileRecvChunk;
+    ret->onFileControl = &chat_onFileControl;
+    ret->onFileRecv = &chat_onFileRecv;
+    ret->onReadReceipt = &chat_onReadReceipt;
 
 #ifdef AUDIO
-    ret.onInvite = &chat_onInvite;
-    ret.onRinging = &chat_onRinging;
-    ret.onStarting = &chat_onStarting;
-    ret.onEnding = &chat_onEnding;
-    ret.onError = &chat_onError;
-    ret.onStart = &chat_onStart;
-    ret.onCancel = &chat_onCancel;
-    ret.onReject = &chat_onReject;
-    ret.onEnd = &chat_onEnd;
+    ret->onInvite = &chat_onInvite;
+    ret->onRinging = &chat_onRinging;
+    ret->onStarting = &chat_onStarting;
+    ret->onEnding = &chat_onEnding;
+    ret->onError = &chat_onError;
+    ret->onStart = &chat_onStart;
+    ret->onCancel = &chat_onCancel;
+    ret->onReject = &chat_onReject;
+    ret->onEnd = &chat_onEnd;
 
-    ret.is_call = false;
-    ret.device_selection[0] = ret.device_selection[1] = -1;
-    ret.ringing_sound = -1;
+    ret->is_call = false;
+    ret->device_selection[0] = ret->device_selection[1] = -1;
+    ret->ringing_sound = -1;
 #endif /* AUDIO */
 
-    ret.active_box = -1;
+    ret->active_box = -1;
 
     char nick[TOX_MAX_NAME_LENGTH];
     size_t n_len = get_nick_truncate(m, nick, friendnum);
-    set_window_title(&ret, nick, n_len);
+    set_window_title(ret, nick, n_len);
 
     ChatContext *chatwin = calloc(1, sizeof(ChatContext));
     StatusBar *stb = calloc(1, sizeof(StatusBar));
@@ -1344,11 +1346,11 @@ ToxWindow new_chat(Tox *m, uint32_t friendnum)
         exit_toxic_err("failed in new_chat", FATALERR_MEMORY);
     }
 
-    ret.chatwin = chatwin;
-    ret.stb = stb;
-    ret.help = help;
+    ret->chatwin = chatwin;
+    ret->stb = stb;
+    ret->help = help;
 
-    ret.num = friendnum;
+    ret->num = friendnum;
 
     return ret;
 }

--- a/src/chat.h
+++ b/src/chat.h
@@ -30,6 +30,6 @@
    set msg to NULL if we don't want to display a message */
 void chat_close_file_receiver(Tox *m, int filenum, int friendnum, int CTRL);
 void kill_chat_window(ToxWindow *self, Tox *m);
-ToxWindow new_chat(Tox *m, int32_t friendnum);
+ToxWindow *new_chat(Tox *m, int32_t friendnum);
 
 #endif /* end of include guard: CHAT_H */

--- a/src/friendlist.c
+++ b/src/friendlist.c
@@ -113,11 +113,9 @@ static void realloc_blocklist(int n)
     Blocked.index = b_idx;
 }
 
-void kill_friendlist(void)
+void kill_friendlist(ToxWindow *self)
 {
-    int i;
-
-    for (i = 0; i < Friends.max_idx; ++i) {
+    for (int i = 0; i < Friends.max_idx; ++i) {
         if (Friends.list[i].active && Friends.list[i].group_invite.key != NULL) {
             free(Friends.list[i].group_invite.key);
         }
@@ -125,6 +123,8 @@ void kill_friendlist(void)
 
     realloc_blocklist(0);
     realloc_friends(0);
+    free(self->help);
+    del_window(self);
 }
 
 /* Saves the blocklist to path. If there are no items in the blocklist the

--- a/src/friendlist.h
+++ b/src/friendlist.h
@@ -81,7 +81,7 @@ typedef struct {
     ToxicFriend *list;
 } FriendsList;
 
-ToxWindow new_friendlist(void);
+ToxWindow *new_friendlist(void);
 void disable_chatwin(uint32_t f_num);
 int get_friendnum(uint8_t *name);
 int load_blocklist(char *data);

--- a/src/friendlist.h
+++ b/src/friendlist.h
@@ -85,7 +85,7 @@ ToxWindow new_friendlist(void);
 void disable_chatwin(uint32_t f_num);
 int get_friendnum(uint8_t *name);
 int load_blocklist(char *data);
-void kill_friendlist(void);
+void kill_friendlist(ToxWindow *self);
 void friendlist_onFriendAdded(ToxWindow *self, Tox *m, uint32_t num, bool sort);
 Tox_User_Status get_friend_status(uint32_t friendnumber);
 Tox_Connection get_friend_connection_status(uint32_t friendnumber);

--- a/src/groupchat.c
+++ b/src/groupchat.c
@@ -113,6 +113,21 @@ static const char group_cmd_list[AC_NUM_GROUP_COMMANDS][MAX_CMDNAME_SIZE] = {
 #endif /* PYTHON */
 };
 
+static void kill_groupchat_window(ToxWindow *self)
+{
+    ChatContext *ctx = self->chatwin;
+
+    log_disable(ctx->log);
+    line_info_cleanup(ctx->hst);
+    delwin(ctx->linewin);
+    delwin(ctx->history);
+    delwin(ctx->sidebar);
+    free(ctx->log);
+    free(ctx);
+    free(self->help);
+    del_window(self);
+}
+
 int init_groupchat_win(ToxWindow *prompt, Tox *m, uint32_t groupnum, uint8_t type)
 {
     if (groupnum > MAX_GROUPCHAT_NUM) {
@@ -120,9 +135,8 @@ int init_groupchat_win(ToxWindow *prompt, Tox *m, uint32_t groupnum, uint8_t typ
     }
 
     ToxWindow self = new_group_chat(m, groupnum);
-    int i;
 
-    for (i = 0; i <= max_groupchat_index; ++i) {
+    for (int i = 0; i <= max_groupchat_index; ++i) {
         if (!groupchats[i].active) {
             groupchats[i].chatwin = add_window(m, self);
             groupchats[i].active = true;
@@ -140,22 +154,9 @@ int init_groupchat_win(ToxWindow *prompt, Tox *m, uint32_t groupnum, uint8_t typ
         }
     }
 
+    kill_groupchat_window(&self);
+
     return -1;
-}
-
-static void kill_groupchat_window(ToxWindow *self)
-{
-    ChatContext *ctx = self->chatwin;
-
-    log_disable(ctx->log);
-    line_info_cleanup(ctx->hst);
-    delwin(ctx->linewin);
-    delwin(ctx->history);
-    delwin(ctx->sidebar);
-    free(ctx->log);
-    free(ctx);
-    free(self->help);
-    del_window(self);
 }
 
 void free_groupchat(ToxWindow *self, Tox *m, uint32_t groupnum)

--- a/src/groupchat.h
+++ b/src/groupchat.h
@@ -61,6 +61,6 @@ int init_groupchat_win(ToxWindow *prompt, Tox *m, uint32_t groupnum, uint8_t typ
 /* destroys and re-creates groupchat window with or without the peerlist */
 void redraw_groupchat_win(ToxWindow *self);
 
-ToxWindow new_group_chat(Tox *m, uint32_t groupnum);
+ToxWindow *new_group_chat(Tox *m, uint32_t groupnum);
 
 #endif /* GROUPCHAT_H */

--- a/src/prompt.c
+++ b/src/prompt.c
@@ -594,22 +594,24 @@ static void prompt_onInit(ToxWindow *self, Tox *m)
     }
 }
 
-ToxWindow new_prompt(void)
+ToxWindow *new_prompt(void)
 {
-    ToxWindow ret;
-    memset(&ret, 0, sizeof(ret));
+    ToxWindow *ret = calloc(1, sizeof(ToxWindow));
 
-    ret.num = -1;
-    ret.active = true;
-    ret.is_prompt = true;
+    if (ret == NULL) {
+        exit_toxic_err("failed in new_prompt", FATALERR_MEMORY);
+    }
 
-    ret.onKey = &prompt_onKey;
-    ret.onDraw = &prompt_onDraw;
-    ret.onInit = &prompt_onInit;
-    ret.onConnectionChange = &prompt_onConnectionChange;
-    ret.onFriendRequest = &prompt_onFriendRequest;
+    ret->num = -1;
+    ret->is_prompt = true;
 
-    strcpy(ret.name, "home");
+    ret->onKey = &prompt_onKey;
+    ret->onDraw = &prompt_onDraw;
+    ret->onInit = &prompt_onInit;
+    ret->onConnectionChange = &prompt_onConnectionChange;
+    ret->onFriendRequest = &prompt_onFriendRequest;
+
+    strcpy(ret->name, "home");
 
     ChatContext *chatwin = calloc(1, sizeof(ChatContext));
     StatusBar *stb = calloc(1, sizeof(StatusBar));
@@ -619,11 +621,11 @@ ToxWindow new_prompt(void)
         exit_toxic_err("failed in new_prompt", FATALERR_MEMORY);
     }
 
-    ret.chatwin = chatwin;
-    ret.stb = stb;
-    ret.help = help;
+    ret->chatwin = chatwin;
+    ret->stb = stb;
+    ret->help = help;
 
-    ret.active_box = -1;
+    ret->active_box = -1;
 
     return ret;
 }

--- a/src/prompt.h
+++ b/src/prompt.h
@@ -42,7 +42,7 @@ typedef struct {
 
 extern FriendRequests FrndRequests;
 
-ToxWindow new_prompt(void);
+ToxWindow *new_prompt(void);
 
 void prep_prompt_win(void);
 void prompt_init_statusbar(ToxWindow *self, Tox *m, bool first_time_run);

--- a/src/toxic.c
+++ b/src/toxic.c
@@ -1281,7 +1281,6 @@ int main(int argc, char **argv)
         arg_opts.encrypt_data = 0;
     }
 
-
     init_term();
 
     prompt = init_windows(m);

--- a/src/windows.c
+++ b/src/windows.c
@@ -667,7 +667,7 @@ void kill_all_windows(Tox *m)
 {
     size_t i;
 
-    for (i = 0; i < MAX_WINDOWS_NUM; ++i) {
+    for (i = 2; i < MAX_WINDOWS_NUM; ++i) {
         if (windows[i].is_chat) {
             kill_chat_window(&windows[i], m);
         } else if (windows[i].is_groupchat) {
@@ -675,6 +675,7 @@ void kill_all_windows(Tox *m)
         }
     }
 
-    kill_prompt_window(prompt);
-    kill_friendlist();
+    /* TODO: use enum instead of magic indices */
+    kill_friendlist(&windows[1]);
+    kill_prompt_window(&windows[0]);
 }

--- a/src/windows.h
+++ b/src/windows.h
@@ -36,7 +36,7 @@
 
 #include "toxic.h"
 
-#define MAX_WINDOWS_NUM 32
+#define MAX_WINDOWS_NUM 16
 #define MAX_WINDOW_NAME_LENGTH 22
 #define CURS_Y_OFFSET 1    /* y-axis cursor offset for chat contexts */
 #define CHATBOX_HEIGHT 2
@@ -162,7 +162,7 @@ struct ToxWindow {
 
     char name[TOXIC_MAX_NAME_LENGTH + 1];
     uint32_t num;    /* corresponds to friendnumber in chat windows */
-    bool active;
+    uint8_t index; /* This window's index in the windows array */
     int x;
 
     bool is_chat;
@@ -252,14 +252,14 @@ struct Help {
 
 ToxWindow *init_windows(Tox *m);
 void draw_active_window(Tox *m);
-int add_window(Tox *m, ToxWindow w);
+int add_window(Tox *m, ToxWindow *w);
 void del_window(ToxWindow *w);
-void set_active_window(int ch);
+void set_active_window_index(uint8_t index);
 int get_num_active_windows(void);
 void kill_all_windows(Tox *m);    /* should only be called on shutdown */
 void on_window_resize(void);
 void force_refresh(WINDOW *w);
-ToxWindow *get_window_ptr(int i);
+ToxWindow *get_window_ptr(size_t i);
 ToxWindow *get_active_window(void);
 
 /* refresh inactive windows to prevent scrolling bugs.


### PR DESCRIPTION
- Fix a couple memory leaks
- Properly clean up `friendlist` window on exit
- Refactor `ToxWindows` so that they're now handled via pointers rather than structs. This significantly reduces the amount of heap memory allocated to the global windows array for an average use case.
- Use `uint8_t` to index windows array, and use C99 style loop counter declarations for related indexing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxic/32)
<!-- Reviewable:end -->
