### PR TITLE
Check for openal lib before attempting to build with video support

### DIFF
--- a/cfg/checks/video.mk
+++ b/cfg/checks/video.mk
@@ -1,5 +1,5 @@
 # Variables for video call support
-VIDEO_LIBS = vpx x11
+VIDEO_LIBS = openal vpx x11
 VIDEO_CFLAGS = -DVIDEO
 ifneq (, $(findstring video_device.o, $(OBJ)))
     VIDEO_OBJ = video_call.o


### PR DESCRIPTION
This prevents toxic from failing to compile with default build options when the video dependencies are present but openal isn't.

The other way to solve this would be to fix the code so that video can compile without audio, but I think it's reasonable to make audio a dependency for video. I am open to input on that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxic/40)
<!-- Reviewable:end -->
