### PR TITLE
Fix A/V hangup bug

### DIFF
--- a/src/audio_call.c
+++ b/src/audio_call.c
@@ -919,8 +919,9 @@ on_error:
 
 void stop_current_call(ToxWindow *self)
 {
+    toxav_call_control(CallControl.av, self->num, TOXAV_CALL_CONTROL_CANCEL, NULL);
+
     if (CallControl.pending_call) {
-        toxav_call_control(CallControl.av, self->num, TOXAV_CALL_CONTROL_CANCEL, NULL);
         callback_call_canceled(self->num);
     } else {
         stop_transmission(&CallControl.calls[self->num], self->num);


### PR DESCRIPTION
The call answerer's call state is no longer set by toxcore after calling `toxav_answer()`. Therefore when the answerer would terminate the call, it would see its own call state as non-existent and never inform the caller of the termination, leaving them in a broken call. I'm not sure if this is a toxic or toxcore bug, or an API "improvement", as the AV API makes no mention of when or if the call state should be set. This PR fixes the problem for now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxic/44)
<!-- Reviewable:end -->
