### PR TITLE
Migrate to Camel_Case enum types.

### DIFF
--- a/src/toxic.c
+++ b/src/toxic.c
@@ -559,7 +559,7 @@ int store_data(Tox *m, const char *path)
             return -1;
         }
 
-        TOX_ERR_ENCRYPTION err;
+        Tox_Err_Encryption err;
         tox_pass_encrypt((uint8_t *) data, data_len, (uint8_t *) user_password.pass, user_password.len,
                          (uint8_t *) enc_data, &err);
 
@@ -736,7 +736,7 @@ static Tox *load_tox(char *data_path, struct Tox_Options *tox_opts, Tox_Err_New 
                     continue;
                 }
 
-                TOX_ERR_DECRYPTION pwerr;
+                Tox_Err_Decryption pwerr;
                 tox_pass_decrypt((uint8_t *) data, len, (uint8_t *) user_password.pass, pwlen,
                                  (uint8_t *) plain, &pwerr);
 


### PR DESCRIPTION
UPPER_CASE enum types are deprecated and will be removed in 0.3.0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxic/50)
<!-- Reviewable:end -->
