### PR TITLE
Fix yamllint warning about missing document start marker.

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,2 @@
+---
 github: [JFreegman]


### PR DESCRIPTION
YAML apparently likes to have this marker, so let's have it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxic/52)
<!-- Reviewable:end -->
