### PR TITLE
Fix unused variable warnings and change all (void)s to UNUSED macro

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -5,17 +5,25 @@ project()
 
 cc_binary(
     name = "toxic",
-    srcs = glob([
-        "src/*.c",
-        "src/*.h",
-    ]),
+    srcs = glob(
+        [
+            "src/*.c",
+            "src/*.h",
+        ],
+        exclude = ["src/video*"],
+    ) + select({
+        "//tools/config:linux": glob(["src/video*"]),
+        "//tools/config:osx": [],
+    }),
     copts = [
         "-DAUDIO",
         "-DPACKAGE_DATADIR='\"data\"'",
         "-DPYTHON",
         "-DQRCODE",
-        "-DVIDEO",
-    ],
+    ] + select({
+        "//tools/config:linux": ["-DVIDEO"],
+        "//tools/config:osx": [],
+    }),
     deps = [
         "//c-toxcore",
         "@curl",
@@ -25,6 +33,8 @@ cc_binary(
         "@ncurses",
         "@openal",
         "@python3//:python",
-        "@x11",
-    ],
+    ] + select({
+        "//tools/config:linux": ["@x11"],
+        "//tools/config:osx": [],
+    }),
 )

--- a/src/audio_device.c
+++ b/src/audio_device.c
@@ -30,17 +30,12 @@
 #include "settings.h"
 #include "misc_tools.h"
 
-#ifdef __APPLE__
-#include <OpenAL/al.h>
-#include <OpenAL/alc.h>
-#else
 #include <AL/al.h>
 #include <AL/alc.h>
 /* compatibility with older versions of OpenAL */
 #ifndef ALC_ALL_DEVICES_SPECIFIER
 #include <AL/alext.h>
 #endif /* ALC_ALL_DEVICES_SPECIFIER */
-#endif /* __APPLE__ */
 
 #include <stdbool.h>
 #include <string.h>

--- a/src/audio_device.c
+++ b/src/audio_device.c
@@ -28,6 +28,7 @@
 
 #include "line_info.h"
 #include "settings.h"
+#include "misc_tools.h"
 
 #ifdef __APPLE__
 #include <OpenAL/al.h>
@@ -461,7 +462,7 @@ void *thread_poll(void *arg)  // TODO: maybe use thread for every input source
     /*
      * NOTE: We only need to poll input devices for data.
      */
-    (void)arg;
+    UNUSED_VAR(arg);
     uint32_t i;
     int32_t sample = 0;
 

--- a/src/chat.c
+++ b/src/chat.c
@@ -901,7 +901,7 @@ static void init_infobox(ToxWindow *self)
         return;
     }
 
-    (void) y2;
+    UNUSED_VAR(y2);
 
     memset(&ctx->infobox, 0, sizeof(struct infobox));
 
@@ -1010,6 +1010,8 @@ static void chat_onKey(ToxWindow *self, Tox *m, wint_t key, bool ltr)
     int x, y, y2, x2;
     getyx(self->window, y, x);
     getmaxyx(self->window, y2, x2);
+
+    UNUSED_VAR(y);
 
     if (y2 <= 0 || x2 <= 0) {
         return;
@@ -1239,7 +1241,9 @@ static void chat_onDraw(ToxWindow *self, Tox *m)
 
     int y, x;
     getyx(self->window, y, x);
-    (void) x;
+
+    UNUSED_VAR(x);
+
     int new_x = ctx->start ? x2 - 1 : MAX(0, wcswidth(ctx->line, ctx->pos));
     wmove(self->window, y + 1, new_x);
 

--- a/src/groupchat.c
+++ b/src/groupchat.c
@@ -488,6 +488,8 @@ static void groupchat_onKey(ToxWindow *self, Tox *m, wint_t key, bool ltr)
     getyx(self->window, y, x);
     getmaxyx(self->window, y2, x2);
 
+    UNUSED_VAR(y);
+
     if (x2 <= 0 || y2 <= 0) {
         return;
     }
@@ -666,7 +668,9 @@ static void groupchat_onDraw(ToxWindow *self, Tox *m)
 
     int y, x;
     getyx(self->window, y, x);
-    (void) x;
+
+    UNUSED_VAR(x);
+
     int new_x = ctx->start ? x2 - 1 : MAX(0, wcswidth(ctx->line, ctx->pos));
     wmove(self->window, y + 1, new_x);
 

--- a/src/help.c
+++ b/src/help.c
@@ -138,7 +138,8 @@ static void help_draw_bottom_menu(WINDOW *win)
 {
     int y2, x2;
     getmaxyx(win, y2, x2);
-    (void) x2;
+
+    UNUSED_VAR(x2);
 
     wmove(win, y2 - 2, 1);
 

--- a/src/line_info.c
+++ b/src/line_info.c
@@ -270,7 +270,8 @@ static void line_info_check_queue(ToxWindow *self)
     int y, y2, x, x2;
     getmaxyx(self->window, y2, x2);
     getyx(self->chatwin->history, y, x);
-    (void) x;
+
+    UNUSED_VAR(x);
 
     if (x2 <= SIDEBAR_WIDTH) {
         return;
@@ -567,7 +568,9 @@ static void line_info_page_up(ToxWindow *self, struct history *hst)
 {
     int x2, y2;
     getmaxyx(self->window, y2, x2);
-    (void) x2;
+
+    UNUSED_VAR(x2);
+
     int jump_dist = y2 / 2;
     int i;
 
@@ -580,7 +583,9 @@ static void line_info_page_down(ToxWindow *self, struct history *hst)
 {
     int x2, y2;
     getmaxyx(self->window, y2, x2);
-    (void) x2;
+
+    UNUSED_VAR(x2);
+
     int jump_dist = y2 / 2;
     int i;
 

--- a/src/notify.c
+++ b/src/notify.c
@@ -235,7 +235,7 @@ void graceful_clear(void)
 
 void *do_playing(void *_p)
 {
-    (void)_p;
+    UNUSED_VAR(_p);
 
     while (true) {
         control_lock();
@@ -334,7 +334,7 @@ int play_source(uint32_t source, uint32_t buffer, bool looping)
 #elif BOX_NOTIFY
 void *do_playing(void *_p)
 {
-    (void)_p;
+    UNUSED_VAR(_p);
 
     while (true) {
         control_lock();

--- a/src/prompt.c
+++ b/src/prompt.c
@@ -220,6 +220,8 @@ static void prompt_onKey(ToxWindow *self, Tox *m, wint_t key, bool ltr)
     getyx(self->window, y, x);
     getmaxyx(self->window, y2, x2);
 
+    UNUSED_VAR(y);
+
     if (x2 <= 0 || y2 <= 0) {
         return;
     }
@@ -416,7 +418,8 @@ static void prompt_onDraw(ToxWindow *self, Tox *m)
 
     int y, x;
     getyx(self->window, y, x);
-    (void) x;
+
+    UNUSED_VAR(x);
 
     int new_x = ctx->start ? x2 - 1 : MAX(0, wcswidth(ctx->line, ctx->pos));
     wmove(self->window, y + 1, new_x);
@@ -508,7 +511,7 @@ void prompt_init_statusbar(ToxWindow *self, Tox *m, bool first_time_run)
         exit_toxic_err("failed in prompt_init_statusbar", FATALERR_CURSES);
     }
 
-    (void) y2;
+    UNUSED_VAR(y2);
 
     /* Init statusbar info */
     StatusBar *statusbar = self->stb;

--- a/src/video_device.c
+++ b/src/video_device.c
@@ -662,7 +662,7 @@ void *video_thread_poll(void *arg)  // TODO: maybe use thread for every input so
     /*
      * NOTE: We only need to poll input devices for data.
      */
-    (void)arg;
+    UNUSED_VAR(arg);
     uint32_t i;
 
     while (1) {

--- a/src/xtra.c
+++ b/src/xtra.c
@@ -23,6 +23,8 @@
 #include "xtra.h"
 #include "misc_tools.h"
 
+#ifndef __APPLE__
+
 #include <X11/Xlib.h>
 #include <X11/Xatom.h>
 
@@ -419,3 +421,5 @@ void terminate_xtra(void)
 
     while (Xtra.display); /* Wait for termination */
 }
+
+#endif /* !__APPLE__ */

--- a/src/xtra.c
+++ b/src/xtra.c
@@ -230,7 +230,7 @@ void *event_loop(void *p)
 {
     /* Handle events like a real nigga */
 
-    (void) p; /* DINDUNOTHIN */
+    UNUSED_VAR(p); /* DINDUNOTHIN */
 
     XEvent event;
     int pending;


### PR DESCRIPTION
Missed these in the last commit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxic/57)
<!-- Reviewable:end -->
