### PR TITLE
Revert "Add feature flags and missing #includes."

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -16,6 +16,7 @@ cc_binary(
         "//tools/config:osx": [],
     }),
     copts = [
+        "-std=gnu99",
         "-DAUDIO",
         "-DPACKAGE_DATADIR='\"data\"'",
         "-DPYTHON",

--- a/src/audio_call.c
+++ b/src/audio_call.c
@@ -41,7 +41,6 @@
 #include <stdbool.h>
 #include <curses.h>
 #include <string.h>
-#include <strings.h>
 #include <pthread.h>
 #include <unistd.h>
 #include <stdlib.h>

--- a/src/audio_device.c
+++ b/src/audio_device.c
@@ -20,9 +20,6 @@
  *
  */
 
-/* TODO(iphydf): use nanosleep instead of usleep */
-#define _XOPEN_SOURCE 500
-
 #include "audio_device.h"
 
 #ifdef AUDIO

--- a/src/autocomplete.c
+++ b/src/autocomplete.c
@@ -22,9 +22,7 @@
 
 #include <stdlib.h>
 #include <string.h>
-#include <strings.h>
 #include <limits.h>
-#include <sys/param.h>
 
 #ifdef __APPLE__
 #include <sys/types.h>

--- a/src/chat_commands.c
+++ b/src/chat_commands.c
@@ -22,7 +22,6 @@
 
 #include <stdlib.h>
 #include <string.h>
-#include <strings.h>
 
 #include "toxic.h"
 #include "windows.h"

--- a/src/configdir.c
+++ b/src/configdir.c
@@ -20,7 +20,6 @@
  *
  */
 
-#define _POSIX_C_SOURCE 200809L
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>

--- a/src/execute.c
+++ b/src/execute.c
@@ -20,7 +20,6 @@
  *
  */
 
-#define _XOPEN_SOURCE 500
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>

--- a/src/file_transfers.h
+++ b/src/file_transfers.h
@@ -24,7 +24,6 @@
 #define FILE_TRANSFERS_H
 
 #include <limits.h>
-#include <sys/param.h>
 
 #include "toxic.h"
 #include "windows.h"

--- a/src/global_commands.c
+++ b/src/global_commands.c
@@ -22,7 +22,6 @@
 
 #include <stdlib.h>
 #include <string.h>
-#include <strings.h>
 
 #include "toxic.h"
 #include "windows.h"

--- a/src/line_info.c
+++ b/src/line_info.c
@@ -20,7 +20,6 @@
  *
  */
 
-#define _DEFAULT_SOURCE
 #include <stdlib.h>
 #include <string.h>
 #include <stdbool.h>

--- a/src/misc_tools.c
+++ b/src/misc_tools.c
@@ -20,12 +20,9 @@
  *
  */
 
-#define _POSIX_C_SOURCE 200809L
-#define _XOPEN_SOURCE 500
 #include <stdlib.h>
 #include <ctype.h>
 #include <string.h>
-#include <strings.h>
 #include <time.h>
 #include <limits.h>
 #include <dirent.h>

--- a/src/misc_tools.h
+++ b/src/misc_tools.h
@@ -23,7 +23,6 @@
 #define MISC_TOOLS_H
 
 #include <sys/stat.h>
-#include <sys/types.h>
 
 #include "windows.h"
 #include "toxic.h"

--- a/src/name_lookup.c
+++ b/src/name_lookup.c
@@ -23,7 +23,6 @@
 #include <stdlib.h>
 #include <stdarg.h>
 #include <string.h>
-#include <strings.h>
 #include <curl/curl.h>
 
 #include "toxic.h"

--- a/src/settings.c
+++ b/src/settings.c
@@ -22,7 +22,6 @@
 
 #include <stdlib.h>
 #include <string.h>
-#include <strings.h>
 #include <libconfig.h>
 #include <ctype.h>
 

--- a/src/settings.h
+++ b/src/settings.h
@@ -24,7 +24,6 @@
 #define SETTINGS_H
 
 #include <limits.h>
-#include <sys/param.h>
 
 #include <tox/tox.h>
 

--- a/src/term_mplex.c
+++ b/src/term_mplex.c
@@ -20,7 +20,6 @@
  *
  */
 
-#define _POSIX_C_SOURCE 2
 #include <limits.h> /* PATH_MAX */
 #include <stdio.h>  /* fgets, popen, pclose */
 #include <stdlib.h> /* malloc, realloc, free, getenv */

--- a/src/toxic.c
+++ b/src/toxic.c
@@ -20,7 +20,6 @@
  *
  */
 
-#define _XOPEN_SOURCE 500
 #include <curses.h>
 #include <errno.h>
 #include <stdio.h>
@@ -31,7 +30,6 @@
 #include <signal.h>
 #include <locale.h>
 #include <string.h>
-#include <strings.h>
 #include <time.h>
 #include <pthread.h>
 #include <getopt.h>

--- a/src/video_call.c
+++ b/src/video_call.c
@@ -33,7 +33,6 @@
 #include <stdbool.h>
 #include <curses.h>
 #include <string.h>
-#include <strings.h>
 #include <pthread.h>
 #include <unistd.h>
 #include <stdlib.h>

--- a/src/video_device.c
+++ b/src/video_device.c
@@ -20,7 +20,6 @@
  *
  */
 
-#define _XOPEN_SOURCE 500
 #include "video_device.h"
 #include "video_call.h"
 

--- a/src/xtra.c
+++ b/src/xtra.c
@@ -20,7 +20,6 @@
  *
  */
 
-#define _XOPEN_SOURCE 500
 #include "xtra.h"
 #include "misc_tools.h"
 


### PR DESCRIPTION
This reverts commit dd5fa236ae1dbd7451420420b0f40f05708bc3c2.

Also, set `-std=gnu99` in Bazel build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxic/65)
<!-- Reviewable:end -->
