### PR TITLE
Remove extra semicolon in lock/unlock macros.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 ---
 language: python
 python: nightly
+dist: xenial
+os: linux
 
 addons:
   apt:

--- a/src/video_device.c
+++ b/src/video_device.c
@@ -102,8 +102,8 @@ uint32_t primary_video_device[2];          /* Primary device */
 static ToxAV *av = NULL;
 
 /* q_mutex */
-#define lock pthread_mutex_lock(&video_mutex);
-#define unlock pthread_mutex_unlock(&video_mutex);
+#define lock pthread_mutex_lock(&video_mutex)
+#define unlock pthread_mutex_unlock(&video_mutex)
 pthread_mutex_t video_mutex;
 
 bool video_thread_running = true,


### PR DESCRIPTION
lock/unlock are always expanded in a context followed by a semicolon.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxic/66)
<!-- Reviewable:end -->
