### PR TITLE
fix: Incorrect file specified error when building in WSL from CLion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ $(BUILD_DIR)/%.o: $(SRC_DIR)/%.c
 	fi
 	@echo "  CC    $(@:$(BUILD_DIR)/%=%)"
 	@$(CC) $(CFLAGS) -o $(BUILD_DIR)/$*.o -c $(SRC_DIR)/$*.c
-	@$(CC) -MM $(CFLAGS) $(SRC_DIR)/$*.c > $(BUILD_DIR)/$*.d
+	@$(CC) -MM $(CFLAGS) $(SRC_DIR)/$*.c >$(BUILD_DIR)/$*.d
 
 clean:
 	rm -f $(BUILD_DIR)/*.d $(BUILD_DIR)/*.o $(BUILD_DIR)/toxic


### PR DESCRIPTION
The full error:
```
Incorrect file specified: '>'. 
Command 'cc -MM -g -std=gnu99 -pthread -Wall -Wpedantic -Wunused -fstack-protector-all '-DTOXICVER="0.8.4_r1903"' -DHAVE_WIDECHAR -D_XOPEN_SOURCE_EXTENDED -D_FILE_OFFSET_BITS=64 '-DPACKAGE_DATADIR="/usr/local/share/toxic"' -DX11 -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -I/usr/include/opus -I/usr/include/x86_64-linux-gnu /mnt/z/toktok/toxic/src/avatars.c > /mnt/z/toktok/toxic/build/avatars.d'
```

Not sure exactly what's going on since clion pushes commands to WSL via ssh and things, but this fixes it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxic/92)
<!-- Reviewable:end -->
