### PR TITLE
cleanup: Dynamically allocate audio frame buffer memory

### DIFF
--- a/src/audio_call.h
+++ b/src/audio_call.h
@@ -87,7 +87,6 @@ extern struct CallControl CallControl;
 ToxAV *init_audio(ToxWindow *self, Tox *tox);
 void terminate_audio(void);
 int start_transmission(ToxWindow *self, Call *call);
-int stop_transmission(Call *call, uint32_t friend_number);
 void stop_current_call(ToxWindow *self);
 void init_friend_AV(uint32_t index);
 void del_friend_AV(uint32_t index);


### PR DESCRIPTION
Continuation of https://github.com/TokTok/toxic/pull/96

This also fixes a long-standing use after free bug. I'm not entirely sure why this PR triggered it, which worries me.

Edit: The call was being cancelled twice, which caused a cascading failure that prevented data structures from being properly cleaned up. All fixed now. This bug was caused by a previous fix for another bug in https://github.com/TokTok/toxic/pull/44. 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxic/98)
<!-- Reviewable:end -->
