### PR TITLE
cleanup: Convert all variable length arrays to heap allocations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ CFG_DIR = $(BASE_DIR)/cfg
 LIBS = toxcore ncursesw libconfig libcurl
 
 CFLAGS ?= -g
-CFLAGS += -std=c99 -pthread -Wall -Wpedantic -Wunused -fstack-protector-all
+CFLAGS += -std=c99 -pthread -Wall -Wpedantic -Wunused -fstack-protector-all -Wvla
 CFLAGS += '-DTOXICVER="$(VERSION)"' -DHAVE_WIDECHAR -D_XOPEN_SOURCE_EXTENDED -D_FILE_OFFSET_BITS=64
 CFLAGS += '-DPACKAGE_DATADIR="$(abspath $(DATADIR))"'
 CFLAGS += ${USER_CFLAGS}

--- a/src/audio_device.c
+++ b/src/audio_device.c
@@ -437,6 +437,7 @@ inline__ DeviceError write_out(uint32_t device_idx, const int16_t *data, uint32_
         ALuint *bufids = malloc(processed * sizeof(ALuint));
 
         if (bufids == NULL) {
+            pthread_mutex_unlock(device->mutex);
             return de_InternalError;
         }
 

--- a/src/autocomplete.h
+++ b/src/autocomplete.h
@@ -28,13 +28,16 @@
  * then fills line with the complete word. e.g. "Hello jo" would complete the line
  * with "Hello john". If multiple matches, prints out all the matches and semi-completes line.
  *
- * list is a pointer to the list of strings being compared, n_items is the number of items
- * in the list, and size is the size of each item in the list.
+* `list` is a pointer to `n_items` strings.
+ *
+ * dir_search should be true if the line being completed is a file path.
  *
  * Returns the difference between the old len and new len of line on success.
  * Returns -1 on error.
+ *
+ * Note: This function should not be called directly. Use complete_line() and complete_path() instead.
  */
-int complete_line(ToxWindow *self, const void *list, size_t n_items, size_t size);
+int complete_line(ToxWindow *self, const char **list, size_t n_items);
 
 /* Attempts to match /command "<incomplete-dir>" line to matching directories.
  * If there is only one match the line is auto-completed.

--- a/src/avatars.c
+++ b/src/avatars.c
@@ -39,6 +39,37 @@ static struct Avatar {
     off_t size;
 } Avatar;
 
+/* Compares the first size bytes of fp to signature.
+ *
+ * Returns 0 if they are the same
+ * Returns 1 if they differ
+ * Returns -1 on error.
+ *
+ * On success this function will seek back to the beginning of fp.
+ */
+static int check_file_signature(const unsigned char *signature, size_t size, FILE *fp)
+{
+    char *buf = malloc(size);
+
+    if (buf == NULL) {
+        return -1;
+    }
+
+    if (fread(buf, size, 1, fp) != 1) {
+        free(buf);
+        return -1;
+    }
+
+    int ret = memcmp(signature, buf, size);
+
+    free(buf);
+
+    if (fseek(fp, 0L, SEEK_SET) == -1) {
+        return -1;
+    }
+
+    return ret == 0 ? 0 : 1;
+}
 
 static void avatar_clear(void)
 {

--- a/src/chat.c
+++ b/src/chat.c
@@ -65,67 +65,50 @@ static void init_infobox(ToxWindow *self);
 static void kill_infobox(ToxWindow *self);
 #endif /* AUDIO */
 
-#ifdef AUDIO
-#define AC_NUM_CHAT_COMMANDS_AUDIO 9
-#else
-#define AC_NUM_CHAT_COMMANDS_AUDIO 0
-#endif /* AUDIO */
-#ifdef PYTHON
-#define AC_NUM_CHAT_COMMANDS_PYTHON 1
-#else
-#define AC_NUM_CHAT_COMMANDS_PYTHON 0
-#endif /* PYTHON */
-#ifdef QRCODE
-#define AC_NUM_CHAT_COMMANDS_QRCODE 1
-#else
-#define AC_NUM_CHAT_COMMANDS_QRCODE 0
-#endif /* QRCODE */
-#define AC_NUM_CHAT_COMMANDS (21 + AC_NUM_CHAT_COMMANDS_AUDIO + AC_NUM_CHAT_COMMANDS_PYTHON + AC_NUM_CHAT_COMMANDS_QRCODE)
-
 /* Array of chat command names used for tab completion. */
-static const char chat_cmd_list[AC_NUM_CHAT_COMMANDS][MAX_CMDNAME_SIZE] = {
-    { "/accept"     },
-    { "/add"        },
-    { "/avatar"     },
-    { "/cancel"     },
-    { "/clear"      },
-    { "/close"      },
-    { "/connect"    },
-    { "/exit"       },
-    { "/group"      },
-    { "/help"       },
-    { "/invite"     },
-    { "/join"       },
-    { "/log"        },
-    { "/myid"       },
+static const char *chat_cmd_list[] = {
+    "/accept",
+    "/add",
+    "/avatar",
+    "/cancel",
+    "/clear",
+    "/close",
+    "/connect",
+    "/exit",
+    "/group",
+    "/help",
+    "/invite",
+    "/join",
+    "/log",
+    "/myid",
 #ifdef QRCODE
-    { "/myqr"       },
+    "/myqr",
 #endif /* QRCODE */
-    { "/nick"       },
-    { "/note"       },
-    { "/nospam"     },
-    { "/quit"       },
-    { "/savefile"   },
-    { "/sendfile"   },
-    { "/status"     },
+    "/nick",
+    "/note",
+    "/nospam",
+    "/quit",
+    "/savefile",
+    "/sendfile",
+    "/status",
 
 #ifdef AUDIO
 
-    { "/call"       },
-    { "/answer"     },
-    { "/reject"     },
-    { "/hangup"     },
-    { "/sdev"       },
-    { "/mute"       },
-    { "/sense"      },
-    { "/video"      },
-    { "/bitrate"    },
+    "/call",
+    "/answer",
+    "/reject",
+    "/hangup",
+    "/sdev",
+    "/mute",
+    "/sense",
+    "/video",
+    "/bitrate",
 
 #endif /* AUDIO */
 
 #ifdef PYTHON
 
-    { "/run"        },
+    "/run",
 
 #endif /* PYTHON */
 };
@@ -662,7 +645,7 @@ static void chat_onFileRecv(ToxWindow *self, Tox *m, uint32_t friendnum, uint32_
         size_t d_len = strlen(d);
 
         if (path_len + d_len >= file_path_buf_size) {
-            path_len -= d_len;
+            path_len = file_path_buf_size - d_len - 1;
             file_path[path_len] = '\0';
         }
 
@@ -1090,14 +1073,14 @@ bool chat_onKey(ToxWindow *self, Tox *m, wint_t key, bool ltr)
 #endif
 
         else if (wcsncmp(ctx->line, L"/status ", wcslen(L"/status ")) == 0) {
-            const char status_cmd_list[3][8] = {
-                {"online"},
-                {"away"},
-                {"busy"},
+            const char *status_cmd_list[] = {
+                "online",
+                "away",
+                "busy",
             };
-            diff = complete_line(self, status_cmd_list, 3, 8);
+            diff = complete_line(self, status_cmd_list, sizeof(status_cmd_list) / sizeof(char *));
         } else {
-            diff = complete_line(self, chat_cmd_list, AC_NUM_CHAT_COMMANDS, MAX_CMDNAME_SIZE);
+            diff = complete_line(self, chat_cmd_list, sizeof(chat_cmd_list) / sizeof(char *));
         }
 
         if (diff != -1) {

--- a/src/file_transfers.c
+++ b/src/file_transfers.c
@@ -81,10 +81,18 @@ void print_progress_bar(ToxWindow *self, double bps, double pct_done, uint32_t l
         strcat(prog_line, "-");
     }
 
-    char full_line[strlen(pct_str) + NUM_PROG_MARKS + strlen(bps_str) + 7];
-    snprintf(full_line, sizeof(full_line), "%s [%s] %s/s", pct_str, prog_line, bps_str);
+    size_t line_buf_size = strlen(pct_str) + NUM_PROG_MARKS + strlen(bps_str) + 7;
+    char *full_line = malloc(line_buf_size);
+
+    if (full_line == NULL) {
+        return;
+    }
+
+    snprintf(full_line, line_buf_size, "%s [%s] %s/s", pct_str, prog_line, bps_str);
 
     line_info_set(self, line_id, full_line);
+
+    free(full_line);
 }
 
 static void refresh_progress_helper(ToxWindow *self, struct FileTransfer *ft)

--- a/src/file_transfers.c
+++ b/src/file_transfers.c
@@ -37,6 +37,7 @@ extern FriendsList Friends;
 
 /* number of "#"'s in file transfer progress bar. Keep well below MAX_STR_SIZE */
 #define NUM_PROG_MARKS 50
+#define STR_BUF_SIZE 30
 
 /* creates initial progress line that will be updated during file transfer.
    Assumes progline has room for at least MAX_STR_SIZE bytes */
@@ -59,10 +60,10 @@ void print_progress_bar(ToxWindow *self, double bps, double pct_done, uint32_t l
         return;
     }
 
-    char pct_str[24];
+    char pct_str[STR_BUF_SIZE] = {0};
     snprintf(pct_str, sizeof(pct_str), "%.1f%%", pct_done);
 
-    char bps_str[24];
+    char bps_str[STR_BUF_SIZE] = {0};
     bytes_convert_str(bps_str, sizeof(bps_str), bps);
 
     char prog_line[NUM_PROG_MARKS + 1] = {0};

--- a/src/global_commands.c
+++ b/src/global_commands.c
@@ -476,45 +476,79 @@ void cmd_myqr(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[MA
     nick[nick_len] = '\0';
 
     size_t data_file_len = strlen(DATA_FILE);
-    char dir[data_file_len + 1];
+    char *dir = malloc(data_file_len + 1);
+
+    if (dir == NULL) {
+        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Failed to create QR code: Out of memory.");
+        return;
+    }
+
     size_t dir_len = get_base_dir(DATA_FILE, data_file_len, dir);
 
 #ifdef QRPNG
 
     if (argc == 0) {
         line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Required 'txt' or 'png'");
+        free(dir);
         return;
     } else if (!strcmp(argv[1], "txt")) {
 
 #endif /* QRPNG */
-        char qr_path[dir_len + nick_len + strlen(QRCODE_FILENAME_EXT) + 1];
-        snprintf(qr_path, sizeof(qr_path), "%s%s%s", dir, nick, QRCODE_FILENAME_EXT);
+        size_t qr_path_buf_size = dir_len + nick_len + strlen(QRCODE_FILENAME_EXT) + 1;
+        char *qr_path = malloc(qr_path_buf_size);
+
+        if (qr_path == NULL) {
+            line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Failed to create QR code: Out of memory");
+            free(dir);
+            return;
+        }
+
+        snprintf(qr_path, qr_path_buf_size, "%s%s%s", dir, nick, QRCODE_FILENAME_EXT);
 
         if (ID_to_QRcode_txt(id_string, qr_path) == -1) {
             line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Failed to create QR code.");
+            free(dir);
+            free(qr_path);
             return;
         }
 
         line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "QR code has been printed to the file '%s'", qr_path);
+
+        free(qr_path);
 
 #ifdef QRPNG
     } else if (!strcmp(argv[1], "png")) {
-        char qr_path[dir_len + nick_len + strlen(QRCODE_FILENAME_EXT_PNG) + 1];
-        snprintf(qr_path, sizeof(qr_path), "%s%s%s", dir, nick, QRCODE_FILENAME_EXT_PNG);
+        size_t qr_path_buf_size = dir_len + nick_len + strlen(QRCODE_FILENAME_EXT_PNG) + 1;
+        char *qr_path = malloc(qr_path_buf_size);
+
+        if (qr_path == NULL) {
+            line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Failed to create QR code: Out of memory");
+            free(dir);
+            return;
+        }
+
+        snprintf(qr_path, qr_path_buf_size, "%s%s%s", dir, nick, QRCODE_FILENAME_EXT_PNG);
 
         if (ID_to_QRcode_png(id_string, qr_path) == -1) {
             line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Failed to create QR code.");
+            free(dir);
+            free(qr_path);
             return;
         }
 
         line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "QR code has been printed to the file '%s'", qr_path);
 
+        free(qr_path);
+
     } else {
         line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Unknown option '%s' -- Required 'txt' or 'png'", argv[1]);
+        free(dir);
         return;
     }
 
 #endif /* QRPNG */
+
+    free(dir);
 }
 #endif /* QRCODE */
 

--- a/src/global_commands.c
+++ b/src/global_commands.c
@@ -494,7 +494,7 @@ void cmd_myqr(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[MA
     } else if (!strcmp(argv[1], "txt")) {
 
 #endif /* QRPNG */
-        size_t qr_path_buf_size = dir_len + nick_len + strlen(QRCODE_FILENAME_EXT) + 1;
+        size_t qr_path_buf_size = dir_len + nick_len + sizeof(QRCODE_FILENAME_EXT);
         char *qr_path = malloc(qr_path_buf_size);
 
         if (qr_path == NULL) {
@@ -518,7 +518,7 @@ void cmd_myqr(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[MA
 
 #ifdef QRPNG
     } else if (!strcmp(argv[1], "png")) {
-        size_t qr_path_buf_size = dir_len + nick_len + strlen(QRCODE_FILENAME_EXT_PNG) + 1;
+        size_t qr_path_buf_size = dir_len + nick_len + sizeof(QRCODE_FILENAME_EXT_PNG);
         char *qr_path = malloc(qr_path_buf_size);
 
         if (qr_path == NULL) {

--- a/src/groupchat.h
+++ b/src/groupchat.h
@@ -48,7 +48,7 @@ typedef struct {
     GroupPeer *peer_list;
     uint32_t max_idx;
 
-    char *name_list;
+    char **name_list;
     uint32_t num_peers;
 
 } GroupChat;

--- a/src/misc_tools.h
+++ b/src/misc_tools.h
@@ -169,10 +169,14 @@ File_Type file_type(const char *path);
 /* returns file size. If file doesn't exist returns 0. */
 off_t file_size(const char *path);
 
-/* compares the first size bytes of fp and signature.
-   Returns 0 if they are the same, 1 if they differ, and -1 on error.
-
-   On success this function will seek back to the beginning of fp */
+/* Compares the first size bytes of fp to signature.
+ *
+ * Returns 0 if they are the same
+ * Returns 1 if they differ
+ * Returns -1 on error.
+ *
+ * On success this function will seek back to the beginning of fp.
+ */
 int check_file_signature(const unsigned char *signature, size_t size, FILE *fp);
 
 /* sets window title in tab bar. */
@@ -189,5 +193,19 @@ bool is_ip4_address(const char *address);
  * reasonably sure that the address is one of the three (ipv4, ipv6 or a domain).
  */
 bool is_ip6_address(const char *address);
+
+
+/*
+ * Frees `length` members of pointer array `arr` and frees `arr`.
+ */
+void free_ptr_array(void **arr, size_t length);
+
+/*
+ * Returns a new array of `length` pointers of size `ptr_size`. Each pointer is allocated `bytes` bytes.
+ * Returns NULL on failure.
+ *
+ * The caller is responsible for freeing the array with `free_ptr_array`.
+ */
+void **malloc_ptr_array(size_t length, size_t bytes, size_t ptr_size);
 
 #endif /* MISC_TOOLS_H */

--- a/src/misc_tools.h
+++ b/src/misc_tools.h
@@ -110,13 +110,16 @@ int qsort_strcasecmp_hlpr(const void *str1, const void *str2);
 /* case-insensitive string compare function for use with qsort */
 int qsort_ptr_char_array_helper(const void *str1, const void *str2);
 
-/* Returns 1 if nick is valid, 0 if not. A valid toxic nick:
-      - cannot be empty
-      - cannot start with a space
-      - must not contain a forward slash (for logfile naming purposes)
-      - must not contain contiguous spaces
-      - must not contain a newline or tab seqeunce */
-int valid_nick(const char *nick);
+/* Returns true if nick is valid.
+ *
+ * A valid toxic nick:
+ * - cannot be empty
+ * - cannot start with a space
+ * - must not contain a forward slash (for logfile naming purposes)
+ * - must not contain contiguous spaces
+ * - must not contain a newline or tab seqeunce
+ */
+bool valid_nick(const char *nick);
 
 /* Converts all newline/tab chars to spaces (use for strings that should be contained to a single line) */
 void filter_str(char *str, size_t len);
@@ -172,31 +175,8 @@ File_Type file_type(const char *path);
 /* returns file size. If file doesn't exist returns 0. */
 off_t file_size(const char *path);
 
-/* Compares the first size bytes of fp to signature.
- *
- * Returns 0 if they are the same
- * Returns 1 if they differ
- * Returns -1 on error.
- *
- * On success this function will seek back to the beginning of fp.
- */
-int check_file_signature(const unsigned char *signature, size_t size, FILE *fp);
-
 /* sets window title in tab bar. */
 void set_window_title(ToxWindow *self, const char *title, int len);
-
-/* Return true if address appears to be a valid ipv4 address. */
-bool is_ip4_address(const char *address);
-
-/* Return true if address roughly appears to be a valid ipv6 address.
- *
- * TODO: Improve this function (inet_pton behaves strangely with ipv6).
- * for now the only guarantee is that it won't return true if the
- * address is a domain or ipv4 address, and should only be used if you're
- * reasonably sure that the address is one of the three (ipv4, ipv6 or a domain).
- */
-bool is_ip6_address(const char *address);
-
 
 /*
  * Frees all members of a pointer array plus `arr`.

--- a/src/misc_tools.h
+++ b/src/misc_tools.h
@@ -107,6 +107,9 @@ void alert_window(ToxWindow *self, int type, bool is_beep);
 /* case-insensitive string compare function for use with qsort */
 int qsort_strcasecmp_hlpr(const void *str1, const void *str2);
 
+/* case-insensitive string compare function for use with qsort */
+int qsort_ptr_char_array_helper(const void *str1, const void *str2);
+
 /* Returns 1 if nick is valid, 0 if not. A valid toxic nick:
       - cannot be empty
       - cannot start with a space
@@ -196,16 +199,16 @@ bool is_ip6_address(const char *address);
 
 
 /*
- * Frees `length` members of pointer array `arr` and frees `arr`.
+ * Frees all members of a pointer array plus `arr`.
  */
-void free_ptr_array(void **arr, size_t length);
+void free_ptr_array(void **arr);
 
 /*
- * Returns a new array of `length` pointers of size `ptr_size`. Each pointer is allocated `bytes` bytes.
+ * Returns a null terminated array of `length` pointers. Each pointer is allocated `bytes` bytes.
  * Returns NULL on failure.
  *
  * The caller is responsible for freeing the array with `free_ptr_array`.
  */
-void **malloc_ptr_array(size_t length, size_t bytes, size_t ptr_size);
+void **malloc_ptr_array(size_t length, size_t bytes);
 
 #endif /* MISC_TOOLS_H */

--- a/src/prompt.c
+++ b/src/prompt.c
@@ -49,68 +49,47 @@ extern struct Winthread Winthread;
 
 extern FriendsList Friends;
 FriendRequests FrndRequests;
-#ifdef AUDIO
-#define AC_NUM_GLOB_COMMANDS_AUDIO 2
-#else
-#define AC_NUM_GLOB_COMMANDS_AUDIO 0
-#endif /* AUDIO */
-#ifdef VIDEO
-#define AC_NUM_GLOB_COMMANDS_VIDEO 2
-#else
-#define AC_NUM_GLOB_COMMANDS_VIDEO 0
-#endif /* VIDEO */
-#ifdef PYTHON
-#define AC_NUM_GLOB_COMMANDS_PYTHON 1
-#else
-#define AC_NUM_GLOB_COMMANDS_PYTHON 0
-#endif /* PYTHON */
-#ifdef QRCODE
-#define AC_NUM_GLOB_COMMANDS_QRCODE 1
-#else
-#define AC_NUM_GLOB_COMMANDS_QRCODE 0
-#endif /* QRCODE */
-#define AC_NUM_GLOB_COMMANDS (17 + AC_NUM_GLOB_COMMANDS_AUDIO + AC_NUM_GLOB_COMMANDS_VIDEO + AC_NUM_GLOB_COMMANDS_PYTHON + AC_NUM_GLOB_COMMANDS_QRCODE)
 
 /* Array of global command names used for tab completion. */
-static const char glob_cmd_list[AC_NUM_GLOB_COMMANDS][MAX_CMDNAME_SIZE] = {
-    { "/accept"     },
-    { "/add"        },
-    { "/avatar"     },
-    { "/clear"      },
-    { "/connect"    },
-    { "/decline"    },
-    { "/exit"       },
-    { "/group"      },
-    { "/help"       },
-    { "/log"        },
-    { "/myid"       },
+static const char *glob_cmd_list[] = {
+    "/accept",
+    "/add",
+    "/avatar",
+    "/clear",
+    "/connect",
+    "/decline",
+    "/exit",
+    "/group",
+    "/help",
+    "/log",
+    "/myid",
 #ifdef QRCODE
-    { "/myqr"       },
+    "/myqr",
 #endif /* QRCODE */
-    { "/nick"       },
-    { "/note"       },
-    { "/nospam"     },
-    { "/quit"       },
-    { "/requests"   },
-    { "/status"     },
+    "/nick",
+    "/note",
+    "/nospam",
+    "/quit",
+    "/requests",
+    "/status",
 
 #ifdef AUDIO
 
-    { "/lsdev"       },
-    { "/sdev"        },
+    "/lsdev",
+    "/sdev",
 
 #endif /* AUDIO */
 
 #ifdef VIDEO
 
-    { "/lsvdev"      },
-    { "/svdev"       },
+    "/lsvdev",
+    "/svdev",
 
 #endif /* VIDEO */
 
 #ifdef PYTHON
 
-    { "/run"         },
+    "/run",
 
 #endif /* PYTHON */
 
@@ -272,14 +251,14 @@ static bool prompt_onKey(ToxWindow *self, Tox *m, wint_t key, bool ltr)
 #endif
 
             else if (wcsncmp(ctx->line, L"/status ", wcslen(L"/status ")) == 0) {
-                const char status_cmd_list[3][8] = {
-                    {"online"},
-                    {"away"},
-                    {"busy"},
+                const char *status_cmd_list[] = {
+                    "online",
+                    "away",
+                    "busy",
                 };
-                diff = complete_line(self, status_cmd_list, 3, 8);
+                diff = complete_line(self, status_cmd_list, sizeof(status_cmd_list) / sizeof(char *));
             } else {
-                diff = complete_line(self, glob_cmd_list, AC_NUM_GLOB_COMMANDS, MAX_CMDNAME_SIZE);
+                diff = complete_line(self, glob_cmd_list, sizeof(glob_cmd_list) / sizeof(char *));
             }
 
             if (diff != -1) {

--- a/src/qr_code.c
+++ b/src/qr_code.c
@@ -138,12 +138,18 @@ int ID_to_QRcode_png(const char *tox_id, const char *outfile)
 
     real_width = (qr_obj->width + BORDER_LEN * 2) * SQUARE_SIZE;
     size_t row_size = real_width * 4;
-    unsigned char row[row_size];
+    unsigned char *row = malloc(row_size);
+
+    if (row == NULL) {
+        fclose(fp);
+        return -1;
+    }
 
     png_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
 
     if (png_ptr == NULL) {
         fclose(fp);
+        free(row);
         QRcode_free(qr_obj);
         return -1;
     }
@@ -152,12 +158,14 @@ int ID_to_QRcode_png(const char *tox_id, const char *outfile)
 
     if (info_ptr == NULL) {
         fclose(fp);
+        free(row);
         QRcode_free(qr_obj);
         return -1;
     }
 
     if (setjmp(png_jmpbuf(png_ptr))) {
         fclose(fp);
+        free(row);
         QRcode_free(qr_obj);
         png_destroy_write_struct(&png_ptr, &info_ptr);
         return -1;
@@ -206,10 +214,12 @@ int ID_to_QRcode_png(const char *tox_id, const char *outfile)
         png_write_row(png_ptr, row);
     }
 
+    free(row);
+    fclose(fp);
+
     png_write_end(png_ptr, info_ptr);
     png_destroy_write_struct(&png_ptr, &info_ptr);
 
-    fclose(fp);
     QRcode_free(qr_obj);
 
     return 0;

--- a/src/qr_code.c
+++ b/src/qr_code.c
@@ -142,6 +142,7 @@ int ID_to_QRcode_png(const char *tox_id, const char *outfile)
 
     if (row == NULL) {
         fclose(fp);
+        QRcode_free(qr_obj);
         return -1;
     }
 

--- a/src/toxic.c
+++ b/src/toxic.c
@@ -794,6 +794,7 @@ static Tox *load_tox(char *data_path, struct Tox_Options *tox_opts, Tox_Err_New 
 
             if (plain == NULL) {
                 fclose(fp);
+                free(data);
                 exit_toxic_err("failed in load_tox", FATALERR_MEMORY);
                 return NULL;
             }
@@ -812,6 +813,7 @@ static Tox *load_tox(char *data_path, struct Tox_Options *tox_opts, Tox_Err_New 
                 if (strcasecmp(user_password.pass, "q") == 0) {
                     fclose(fp);
                     free(plain);
+                    free(data);
                     exit(0);
                 }
 
@@ -1294,7 +1296,7 @@ static int rename_old_profile(const char *user_config_dir)
         return -1;
     }
 
-    snprintf(old_data_blocklist, sizeof(old_data_blocklist), "%s%s%s", user_config_dir, CONFIGDIR, OLD_DATA_BLOCKLIST_NAME);
+    snprintf(old_data_blocklist, old_block_buf_size, "%s%s%s", user_config_dir, CONFIGDIR, OLD_DATA_BLOCKLIST_NAME);
 
     if (!file_exists(old_data_blocklist)) {
         free(old_data_blocklist);

--- a/src/toxic.c
+++ b/src/toxic.c
@@ -742,7 +742,6 @@ static Tox *load_tox(char *data_path, struct Tox_Options *tox_opts, Tox_Err_New 
         if (len == 0) {
             fclose(fp);
             exit_toxic_err("failed in load_tox", FATALERR_FILEOP);
-            return NULL;
         }
 
         char *data = malloc(len);
@@ -750,14 +749,12 @@ static Tox *load_tox(char *data_path, struct Tox_Options *tox_opts, Tox_Err_New 
         if (data == NULL) {
             fclose(fp);
             exit_toxic_err("failed in load_tox", FATALERR_MEMORY);
-            return NULL;
         }
 
         if (fread(data, len, 1, fp) != 1) {
             fclose(fp);
             free(data);
             exit_toxic_err("failed in load_tox", FATALERR_FILEOP);
-            return NULL;
         }
 
         bool is_encrypted = tox_is_data_encrypted((uint8_t *) data);
@@ -767,7 +764,6 @@ static Tox *load_tox(char *data_path, struct Tox_Options *tox_opts, Tox_Err_New 
             fclose(fp);
             free(data);
             exit_toxic_err("failed in load_tox", FATALERR_ENCRYPT);
-            return NULL;
         }
 
         if (arg_opts.unencrypt_data && is_encrypted) {
@@ -796,7 +792,6 @@ static Tox *load_tox(char *data_path, struct Tox_Options *tox_opts, Tox_Err_New 
                 fclose(fp);
                 free(data);
                 exit_toxic_err("failed in load_tox", FATALERR_MEMORY);
-                return NULL;
             }
 
             while (true) {
@@ -853,7 +848,6 @@ static Tox *load_tox(char *data_path, struct Tox_Options *tox_opts, Tox_Err_New 
                     free(data);
                     free(plain);
                     exit_toxic_err("tox_pass_decrypt() failed", pwerr);
-                    return NULL;
                 }
             }
 
@@ -876,7 +870,6 @@ static Tox *load_tox(char *data_path, struct Tox_Options *tox_opts, Tox_Err_New 
     } else {   /* Data file does not/should not exist */
         if (file_exists(data_path)) {
             exit_toxic_err("failed in load_tox", FATALERR_FILEOP);
-            return NULL;
         }
 
         tox_options_set_savedata_type(tox_opts, TOX_SAVEDATA_TYPE_NONE);
@@ -889,7 +882,6 @@ static Tox *load_tox(char *data_path, struct Tox_Options *tox_opts, Tox_Err_New 
 
         if (store_data(m, data_path) == -1) {
             exit_toxic_err("failed in load_tox", FATALERR_FILEOP);
-            return NULL;
         }
     }
 


### PR DESCRIPTION
VLA's are inherently unsafe so the safest option is to not use them. The trade off here is a lot of extra code for mallocs/frees and more possible memory leaks. But I think that's a small price to pay for greatly reducing the possibility of stack corruption.

I also added the -Wvla compile option to the Makefile, which gives a warning when VLA's are used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxic/100)
<!-- Reviewable:end -->
