### PR TITLE
chore: Use c99 standard instead of gnu99

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ CFG_DIR = $(BASE_DIR)/cfg
 LIBS = toxcore ncursesw libconfig libcurl
 
 CFLAGS ?= -g
-CFLAGS += -std=gnu99 -pthread -Wall -Wpedantic -Wunused -fstack-protector-all
+CFLAGS += -std=c99 -pthread -Wall -Wpedantic -Wunused -fstack-protector-all
 CFLAGS += '-DTOXICVER="$(VERSION)"' -DHAVE_WIDECHAR -D_XOPEN_SOURCE_EXTENDED -D_FILE_OFFSET_BITS=64
 CFLAGS += '-DPACKAGE_DATADIR="$(abspath $(DATADIR))"'
 CFLAGS += ${USER_CFLAGS}


### PR DESCRIPTION
No gnu99 extensions are used or will be used

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxic/103)
<!-- Reviewable:end -->
