### PR TITLE
cleanup: Replace deprecated usleep function with nanosleep

### DIFF
--- a/src/audio_device.c
+++ b/src/audio_device.c
@@ -123,7 +123,7 @@ DeviceError terminate_devices(void)
     thread_running = false;
     unlock;
 
-    usleep(20000);
+    sleep_thread(20000L);
 
     if (pthread_mutex_destroy(&mutex) != 0) {
         return (DeviceError) de_InternalError;
@@ -499,7 +499,7 @@ void *thread_poll(void *arg)  // TODO: maybe use thread for every input source
 
         /* Wait for unpause. */
         if (paused) {
-            usleep(10000);
+            sleep_thread(10000L);
         }
 
         else {
@@ -533,7 +533,7 @@ void *thread_poll(void *arg)  // TODO: maybe use thread for every input source
                 unlock;
             }
 
-            usleep(5000);
+            sleep_thread(5000L);
         }
     }
 

--- a/src/misc_tools.c
+++ b/src/misc_tools.c
@@ -70,6 +70,19 @@ int timed_out(time_t timestamp, time_t timeout)
     return timestamp + timeout <= get_unix_time();
 }
 
+/* Sleeps the caller's thread for `usec` microseconds */
+void sleep_thread(long int usec)
+{
+    struct timespec req;
+
+    req.tv_sec = 0;
+    req.tv_nsec = usec * 1000L;
+
+    if (nanosleep(&req, NULL) == -1) {
+        fprintf(stderr, "nanosleep() returned -1\n");
+    }
+}
+
 /* Get the current local time */
 struct tm *get_time(void)
 {

--- a/src/misc_tools.h
+++ b/src/misc_tools.h
@@ -101,6 +101,9 @@ int mbs_to_wcs_buf(wchar_t *buf, const char *string, size_t n);
 /* Returns 1 if connection has timed out, 0 otherwise */
 int timed_out(time_t timestamp, time_t timeout);
 
+/* Sleeps the caller's thread for `usec` microseconds */
+void sleep_thread(long int usec);
+
 /* Colours the window tab according to type. Beeps if is_beep is true */
 void alert_window(ToxWindow *self, int type, bool is_beep);
 

--- a/src/notify.c
+++ b/src/notify.c
@@ -227,7 +227,7 @@ void graceful_clear(void)
             return;
         }
 
-        usleep(1000);
+        sleep_thread(1000L);
     }
 
     control_unlock();
@@ -305,7 +305,7 @@ void *do_playing(void *_p)
         has_looping = false;
 
         control_unlock();
-        usleep(10000);
+        sleep_thread(10000L);
     }
 
     pthread_exit(NULL);
@@ -361,7 +361,7 @@ void *do_playing(void *_p)
         }
 
         control_unlock();
-        usleep(10000);
+        sleep_thread(10000L);
     }
 
     pthread_exit(NULL);

--- a/src/toxic.c
+++ b/src/toxic.c
@@ -995,7 +995,7 @@ void *thread_cqueue(void *data)
 
         pthread_mutex_unlock(&Winthread.lock);
 
-        usleep(4000);
+        sleep_thread(4000L);
     }
 }
 
@@ -1009,7 +1009,8 @@ void *thread_av(void *data)
         toxav_iterate(av);
         pthread_mutex_unlock(&Winthread.lock);
 
-        usleep(toxav_iteration_interval(av) * 1000);
+        long int sleep_duration = toxav_iteration_interval(av) * 1000;
+        sleep_thread(sleep_duration);
     }
 }
 #endif /* AUDIO */
@@ -1513,7 +1514,8 @@ int main(int argc, char **argv)
             last_save = cur_time;
         }
 
-        usleep(tox_iteration_interval(m) * 1000);
+        long int sleep_duration = tox_iteration_interval(m) * 1000;
+        sleep_thread(sleep_duration);
     }
 
     return 0;

--- a/src/video_device.c
+++ b/src/video_device.c
@@ -258,7 +258,7 @@ VideoDeviceError terminate_video_devices(void)
     video_thread_running = false;
     unlock;
 
-    usleep(20000);
+    sleep_thread(20000L);
 
     int i;
 
@@ -676,7 +676,7 @@ void *video_thread_poll(void *arg)  // TODO: maybe use thread for every input so
         unlock;
 
         if (video_thread_paused) {
-            usleep(10000);    /* Wait for unpause. */
+            sleep_thread(10000L);    /* Wait for unpause. */
         } else {
             for (i = 0; i < size[vdt_input]; ++i) {
                 lock;
@@ -765,7 +765,8 @@ void *video_thread_poll(void *arg)  // TODO: maybe use thread for every input so
                 unlock;
             }
 
-            usleep(1000 * 1000 / 24);
+            long int sleep_duration = 1000 * 1000 / 24;
+            sleep_thread(sleep_duration);
         }
     }
 

--- a/src/xtra.c
+++ b/src/xtra.c
@@ -248,7 +248,7 @@ void *event_loop(void *p)
 
         if (!pending) {
             XUnlockDisplay(Xtra.display);
-            usleep(10000);
+            sleep_thread(10000L);
             continue;
         }
 


### PR DESCRIPTION
usleep was declared obsolete in POSIX.1-2001

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxic/109)
<!-- Reviewable:end -->
