### PR TITLE
fix: Race condition

### DIFF
--- a/src/chat.c
+++ b/src/chat.c
@@ -152,6 +152,7 @@ void kill_chat_window(ToxWindow *self, Tox *m)
     free(statusbar);
 
     disable_chatwin(self->num);
+    kill_notifs(self->active_box);
     del_window(self);
 }
 

--- a/src/conference.c
+++ b/src/conference.c
@@ -116,6 +116,7 @@ static void kill_conference_window(ToxWindow *self)
     free(ctx->log);
     free(ctx);
     free(self->help);
+    kill_notifs(self->active_box);
     del_window(self);
 }
 

--- a/src/notify.h
+++ b/src/notify.h
@@ -62,6 +62,9 @@ typedef enum _Flags {
 int init_notify(int login_cooldown, int notification_timeout);
 void terminate_notify(void);
 
+/* Kills all notifications for `id`. This must be called before freeing a ToxWindow. */
+void kill_notifs(int id);
+
 int sound_notify(ToxWindow *self, Notification notif, uint64_t flags, int *id_indicator);
 int sound_notify2(ToxWindow *self, Notification notif, uint64_t flags, int id);
 


### PR DESCRIPTION
A ToxWindow's notifications need to be halted before the window is freed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxic/119)
<!-- Reviewable:end -->
