### PR TITLE
cleanup: Use compound literals to zero out structs instead of memset

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ CFG_DIR = $(BASE_DIR)/cfg
 LIBS = toxcore ncursesw libconfig libcurl
 
 CFLAGS ?= -g
-CFLAGS += -std=c99 -pthread -Wall -Wpedantic -Wunused -fstack-protector-all -Wvla
+CFLAGS += -std=c99 -pthread -Wall -Wpedantic -Wunused -fstack-protector-all -Wvla -Wmissing-field-initializers -Wno-missing-braces
 CFLAGS += '-DTOXICVER="$(VERSION)"' -DHAVE_WIDECHAR -D_XOPEN_SOURCE_EXTENDED -D_FILE_OFFSET_BITS=64
 CFLAGS += '-DPACKAGE_DATADIR="$(abspath $(DATADIR))"'
 CFLAGS += ${USER_CFLAGS}

--- a/src/audio_call.c
+++ b/src/audio_call.c
@@ -1008,7 +1008,10 @@ static void realloc_calls(uint32_t n)
 void init_friend_AV(uint32_t index)
 {
     realloc_calls(CallControl.max_calls + 1);
-    memset(&CallControl.calls[CallControl.max_calls], 0, sizeof(Call));
+
+    CallControl.calls[CallControl.max_calls] = (Call) {
+        0
+    };
 
     if (index == CallControl.max_calls) {
         ++CallControl.max_calls;

--- a/src/avatars.c
+++ b/src/avatars.c
@@ -73,7 +73,9 @@ static int check_file_signature(const unsigned char *signature, size_t size, FIL
 
 static void avatar_clear(void)
 {
-    memset(&Avatar, 0, sizeof(struct Avatar));
+    Avatar = (struct Avatar) {
+        0
+    };
 }
 
 /* Sends avatar to friendnum.

--- a/src/chat.c
+++ b/src/chat.c
@@ -946,7 +946,9 @@ static void init_infobox(ToxWindow *self)
 
     UNUSED_VAR(y2);
 
-    memset(&ctx->infobox, 0, sizeof(struct infobox));
+    ctx->infobox = (struct infobox) {
+        0
+    };
 
     ctx->infobox.win = newwin(INFOBOX_HEIGHT, INFOBOX_WIDTH + 1, 1, x2 - INFOBOX_WIDTH);
     ctx->infobox.starttime = get_unix_time();
@@ -964,7 +966,10 @@ static void kill_infobox(ToxWindow *self)
     }
 
     delwin(ctx->infobox.win);
-    memset(&ctx->infobox, 0, sizeof(struct infobox));
+
+    ctx->infobox = (struct infobox) {
+        0
+    };
 }
 
 /* update infobox info and draw in respective chat window */
@@ -1142,7 +1147,7 @@ bool chat_onKey(ToxWindow *self, Tox *m, wint_t key, bool ltr)
             char line[MAX_STR_SIZE] = {0};
 
             if (wcs_to_mbs_buf(line, ctx->line, MAX_STR_SIZE) == -1) {
-                memset(&line, 0, sizeof(line));
+                memset(line, 0, sizeof(line));
             }
 
             if (line[0] == '/') {

--- a/src/conference.c
+++ b/src/conference.c
@@ -157,7 +157,10 @@ void free_conference(ToxWindow *self, uint32_t conferencenum)
 {
     free_ptr_array((void **) conferences[conferencenum].name_list);
     free(conferences[conferencenum].peer_list);
-    memset(&conferences[conferencenum], 0, sizeof(ConferenceChat));
+
+    conferences[conferencenum] = (ConferenceChat) {
+        0
+    };
 
     int i;
 
@@ -577,7 +580,7 @@ static bool conference_onKey(ToxWindow *self, Tox *m, wint_t key, bool ltr)
             char line[MAX_STR_SIZE];
 
             if (wcs_to_mbs_buf(line, ctx->line, MAX_STR_SIZE) == -1) {
-                memset(&line, 0, sizeof(line));
+                memset(line, 0, sizeof(line));
             }
 
             if (line[0] == '/') {

--- a/src/file_transfers.c
+++ b/src/file_transfers.c
@@ -126,14 +126,19 @@ void refresh_file_transfer_progress(ToxWindow *self, uint32_t friendnum)
     }
 }
 
+static void clear_file_transfer(struct FileTransfer *ft)
+{
+    *ft = (struct FileTransfer) {
+        0
+    };
+}
+
 /* Returns a pointer to friendnum's FileTransfer struct associated with filenum.
  * Returns NULL if filenum is invalid.
  */
 struct FileTransfer *get_file_transfer_struct(uint32_t friendnum, uint32_t filenum)
 {
-    size_t i;
-
-    for (i = 0; i < MAX_FILES; ++i) {
+    for (size_t i = 0; i < MAX_FILES; ++i) {
         struct FileTransfer *ft_send = &Friends.list[friendnum].file_sender[i];
 
         if (ft_send->state != FILE_TRANSFER_INACTIVE && ft_send->filenum == filenum) {
@@ -160,9 +165,7 @@ struct FileTransfer *get_file_transfer_struct_index(uint32_t friendnum, uint32_t
         return NULL;
     }
 
-    size_t i;
-
-    for (i = 0; i < MAX_FILES; ++i) {
+    for (size_t i = 0; i < MAX_FILES; ++i) {
         struct FileTransfer *ft = direction == FILE_TRANSFER_SEND ?
                                       &Friends.list[friendnum].file_sender[i] :
                                       &Friends.list[friendnum].file_receiver[i];
@@ -180,13 +183,11 @@ struct FileTransfer *get_file_transfer_struct_index(uint32_t friendnum, uint32_t
  */
 static struct FileTransfer *new_file_sender(ToxWindow *window, uint32_t friendnum, uint32_t filenum, uint8_t type)
 {
-    size_t i;
-
-    for (i = 0; i < MAX_FILES; ++i) {
+    for (size_t i = 0; i < MAX_FILES; ++i) {
         struct FileTransfer *ft = &Friends.list[friendnum].file_sender[i];
 
         if (ft->state == FILE_TRANSFER_INACTIVE) {
-            memset(ft, 0, sizeof(struct FileTransfer));
+            clear_file_transfer(ft);
             ft->window = window;
             ft->index = i;
             ft->friendnum = friendnum;
@@ -207,13 +208,11 @@ static struct FileTransfer *new_file_sender(ToxWindow *window, uint32_t friendnu
  */
 static struct FileTransfer *new_file_receiver(ToxWindow *window, uint32_t friendnum, uint32_t filenum, uint8_t type)
 {
-    size_t i;
-
-    for (i = 0; i < MAX_FILES; ++i) {
+    for (size_t i = 0; i < MAX_FILES; ++i) {
         struct FileTransfer *ft = &Friends.list[friendnum].file_receiver[i];
 
         if (ft->state == FILE_TRANSFER_INACTIVE) {
-            memset(ft, 0, sizeof(struct FileTransfer));
+            clear_file_transfer(ft);
             ft->window = window;
             ft->index = i;
             ft->friendnum = friendnum;
@@ -281,7 +280,7 @@ void close_file_transfer(ToxWindow *self, Tox *m, struct FileTransfer *ft, int C
         line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "%s", message);
     }
 
-    memset(ft, 0, sizeof(struct FileTransfer));
+    clear_file_transfer(ft);
 }
 
 /* Kills all active file transfers for friendnum */

--- a/src/friendlist.c
+++ b/src/friendlist.c
@@ -127,6 +127,20 @@ void kill_friendlist(ToxWindow *self)
     del_window(self);
 }
 
+static void clear_blocklist_index(size_t idx)
+{
+    Blocked.list[idx] = (BlockedFriend) {
+        0
+    };
+}
+
+static void clear_friendlist_index(size_t idx)
+{
+    Friends.list[idx] = (ToxicFriend) {
+        0
+    };
+}
+
 /* Saves the blocklist to path. If there are no items in the blocklist the
  * empty file will be removed.
  *
@@ -160,8 +174,7 @@ static int save_blocklist(char *path)
                 continue;
             }
 
-            BlockedFriend tmp;
-            memset(&tmp, 0, sizeof(BlockedFriend));
+            BlockedFriend tmp = {0};
             tmp.namelength = htons(Blocked.list[i].namelength);
             memcpy(tmp.name, Blocked.list[i].name, Blocked.list[i].namelength + 1);  // Include null byte
             memcpy(tmp.pub_key, Blocked.list[i].pub_key, TOX_PUBLIC_KEY_SIZE);
@@ -271,9 +284,8 @@ int load_blocklist(char *path)
     realloc_blocklist(num);
 
     for (int i = 0; i < num; ++i) {
-        BlockedFriend tmp;
-        memset(&tmp, 0, sizeof(BlockedFriend));
-        memset(&Blocked.list[i], 0, sizeof(BlockedFriend));
+        BlockedFriend tmp = {0};
+        clear_blocklist_index(i);
 
         memcpy(&tmp, data + i * sizeof(BlockedFriend), sizeof(BlockedFriend));
         Blocked.list[i].namelength = ntohs(tmp.namelength);
@@ -476,7 +488,7 @@ void friendlist_onFriendAdded(ToxWindow *self, Tox *m, uint32_t num, bool sort)
     UNUSED_VAR(self);
 
     realloc_friends(Friends.max_idx + 1);
-    memset(&Friends.list[Friends.max_idx], 0, sizeof(ToxicFriend));
+    clear_friendlist_index(Friends.max_idx);
 
     uint32_t i;
 
@@ -536,7 +548,7 @@ void friendlist_onFriendAdded(ToxWindow *self, Tox *m, uint32_t num, bool sort)
 static void friendlist_add_blocked(uint32_t fnum, uint32_t bnum)
 {
     realloc_friends(Friends.max_idx + 1);
-    memset(&Friends.list[Friends.max_idx], 0, sizeof(ToxicFriend));
+    clear_friendlist_index(Friends.max_idx);
 
     int i;
 
@@ -679,7 +691,7 @@ static void delete_friend(Tox *m, uint32_t f_num)
         free(Friends.list[f_num].conference_invite.key);
     }
 
-    memset(&Friends.list[f_num], 0, sizeof(ToxicFriend));
+    clear_friendlist_index(f_num);
 
     int i;
 
@@ -728,7 +740,11 @@ static void del_friend_deactivate(Tox *m, wint_t key)
     }
 
     delwin(PendingDelete.popup);
-    memset(&PendingDelete, 0, sizeof(PendingDelete));
+
+    PendingDelete = (struct PendingDel) {
+        0
+    };
+
     clear();
     refresh();
 }
@@ -766,7 +782,7 @@ static void draw_del_popup(void)
 /* deletes contact from blocked list */
 static void delete_blocked_friend(uint32_t bnum)
 {
-    memset(&Blocked.list[bnum], 0, sizeof(BlockedFriend));
+    clear_blocklist_index(bnum);
 
     int i;
 
@@ -794,7 +810,7 @@ void block_friend(Tox *m, uint32_t fnum)
     }
 
     realloc_blocklist(Blocked.max_idx + 1);
-    memset(&Blocked.list[Blocked.max_idx], 0, sizeof(BlockedFriend));
+    clear_blocklist_index(Blocked.max_idx);
 
     int i;
 

--- a/src/global_commands.c
+++ b/src/global_commands.c
@@ -76,7 +76,9 @@ void cmd_accept(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[
         on_friend_added(m, friendnum, true);
     }
 
-    memset(&FrndRequests.request[req], 0, sizeof(struct friend_request));
+    FrndRequests.request[req] = (struct friend_request) {
+        0
+    };
 
     int i;
 
@@ -322,7 +324,9 @@ void cmd_decline(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)
         return;
     }
 
-    memset(&FrndRequests.request[req], 0, sizeof(struct friend_request));
+    FrndRequests.request[req] = (struct friend_request) {
+        0
+    };
 
     int i;
 

--- a/src/help.c
+++ b/src/help.c
@@ -59,7 +59,10 @@ void help_init_menu(ToxWindow *self)
 static void help_exit(ToxWindow *self)
 {
     delwin(self->help->win);
-    memset(self->help, 0, sizeof(Help));
+
+    *(self->help) = (struct Help) {
+        0
+    };
 }
 
 static void help_init_window(ToxWindow *self, int height, int width)

--- a/src/log.c
+++ b/src/log.c
@@ -158,7 +158,9 @@ void log_disable(struct chatlog *log)
         fclose(log->file);
     }
 
-    memset(log, 0, sizeof(struct chatlog));
+    *log = (struct chatlog) {
+        0
+    };
 }
 
 int log_enable(char *name, const char *selfkey, const char *otherkey, struct chatlog *log, int logtype)

--- a/src/name_lookup.c
+++ b/src/name_lookup.c
@@ -63,6 +63,13 @@ static struct lookup_thread {
     pthread_attr_t attr;
 } lookup_thread;
 
+static void clear_thread_data(void)
+{
+    t_data = (struct thread_data) {
+        0
+    };
+}
+
 static int lookup_error(ToxWindow *self, const char *errmsg, ...)
 {
     char frmt_msg[MAX_STR_SIZE];
@@ -81,7 +88,7 @@ static int lookup_error(ToxWindow *self, const char *errmsg, ...)
 
 static void kill_lookup_thread(void)
 {
-    memset(&t_data, 0, sizeof(struct thread_data));
+    clear_thread_data();
     pthread_attr_destroy(&lookup_thread.attr);
     pthread_exit(NULL);
 }
@@ -376,21 +383,21 @@ void name_lookup(ToxWindow *self, Tox *m, const char *id_bin, const char *addr, 
 
     if (pthread_attr_init(&lookup_thread.attr) != 0) {
         line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, RED, "Error: lookup thread attr failed to init");
-        memset(&t_data, 0, sizeof(struct thread_data));
+        clear_thread_data();
         return;
     }
 
     if (pthread_attr_setdetachstate(&lookup_thread.attr, PTHREAD_CREATE_DETACHED) != 0) {
         line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, RED, "Error: lookup thread attr failed to set");
         pthread_attr_destroy(&lookup_thread.attr);
-        memset(&t_data, 0, sizeof(struct thread_data));
+        clear_thread_data();
         return;
     }
 
     if (pthread_create(&lookup_thread.tid, &lookup_thread.attr, lookup_thread_func, NULL) != 0) {
         line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, RED, "Error: lookup thread failed to init");
         pthread_attr_destroy(&lookup_thread.attr);
-        memset(&t_data, 0, sizeof(struct thread_data));
+        clear_thread_data();
         return;
     }
 }

--- a/src/prompt.c
+++ b/src/prompt.c
@@ -284,7 +284,7 @@ static bool prompt_onKey(ToxWindow *self, Tox *m, wint_t key, bool ltr)
             char line[MAX_STR_SIZE] = {0};
 
             if (wcs_to_mbs_buf(line, ctx->line, MAX_STR_SIZE) == -1) {
-                memset(&line, 0, sizeof(line));
+                memset(line, 0, sizeof(line));
             }
 
             line_info_add(self, NULL, NULL, NULL, PROMPT, 0, 0, "%s", line);

--- a/src/toxic.c
+++ b/src/toxic.c
@@ -173,7 +173,10 @@ void free_global_data(void)
 void exit_toxic_success(Tox *m)
 {
     store_data(m, DATA_FILE);
-    memset(&user_password, 0, sizeof(struct user_password));
+
+    user_password = (struct user_password) {
+        0
+    };
 
     terminate_notify();
 
@@ -1046,7 +1049,9 @@ static void print_version(void)
 
 static void set_default_opts(void)
 {
-    memset(&arg_opts, 0, sizeof(struct arg_opts));
+    arg_opts = (struct arg_opts) {
+        0
+    };
 
     /* set any non-zero defaults here*/
     arg_opts.proxy_type = TOX_PROXY_TYPE_NONE;

--- a/src/video_device.c
+++ b/src/video_device.c
@@ -401,8 +401,7 @@ VideoDeviceError open_video_device(VideoDeviceType type, int32_t selection, uint
         }
 
         /* Setup video format */
-        struct v4l2_format fmt;
-        memset(&(fmt), 0, sizeof(fmt));
+        struct v4l2_format fmt = {0};
 
         fmt.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
         fmt.fmt.pix.pixelformat = V4L2_PIX_FMT_YUYV;
@@ -418,8 +417,8 @@ VideoDeviceError open_video_device(VideoDeviceType type, int32_t selection, uint
         device->video_height = fmt.fmt.pix.height;
 
         /* Request buffers */
-        struct v4l2_requestbuffers req;
-        memset(&(req), 0, sizeof(req));
+        struct v4l2_requestbuffers req = {0};
+
         req.count = 4;
         req.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
         req.memory = V4L2_MEMORY_MMAP;
@@ -441,8 +440,7 @@ VideoDeviceError open_video_device(VideoDeviceType type, int32_t selection, uint
         device->buffers = calloc(req.count, sizeof(struct VideoBuffer));
 
         for (i = 0; i < req.count; ++i) {
-            struct v4l2_buffer buf;
-            memset(&(buf), 0, sizeof(buf));
+            struct v4l2_buffer buf = {0};
 
             buf.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
             buf.memory = V4L2_MEMORY_MMAP;
@@ -479,8 +477,7 @@ VideoDeviceError open_video_device(VideoDeviceType type, int32_t selection, uint
         enum v4l2_buf_type type;
 
         for (i = 0; i < device->n_buffers; ++i) {
-            struct v4l2_buffer buf;
-            memset(&(buf), 0, sizeof(buf));
+            struct v4l2_buffer buf = {0};
 
             buf.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
             buf.memory = V4L2_MEMORY_MMAP;
@@ -698,8 +695,7 @@ void *video_thread_poll(void *arg)  // TODO: maybe use thread for every input so
                     }
 
 #else /* not __OSX__ || __APPLE__ */
-                    struct v4l2_buffer buf;
-                    memset(&(buf), 0, sizeof(buf));
+                    struct v4l2_buffer buf = {0};
 
                     buf.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
                     buf.memory = V4L2_MEMORY_MMAP;


### PR DESCRIPTION
This is cleaner and much less prone to bugs.

`Wno-missing-bracers` was added to the makefile because Clang was giving lots of false positives. `Wmissing-field-initializers` was added because it basically does what `Wmissing-bracers` does but without the false positives.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxic/122)
<!-- Reviewable:end -->
