### PR TITLE
cleanup: Refactor message queue

### DIFF
--- a/src/message_queue.h
+++ b/src/message_queue.h
@@ -27,9 +27,9 @@ struct cqueue_msg {
     char message[MAX_STR_SIZE];
     size_t len;
     int line_id;
-    uint8_t type;
-    uint32_t receipt;
     time_t last_send_try;
+    uint8_t type;
+    int64_t receipt;
     struct cqueue_msg *next;
     struct cqueue_msg *prev;
 };
@@ -42,7 +42,10 @@ struct chat_queue {
 void cqueue_cleanup(struct chat_queue *q);
 void cqueue_add(struct chat_queue *q, const char *msg, size_t len, uint8_t type, int line_id);
 
-/* Tries to send the oldest unsent message in queue. */
+/*
+ * Tries to send all messages in the send queue in sequential order.
+ * If a message fails to send the function will immediately return.
+ */
 void cqueue_try_send(ToxWindow *self, Tox *m);
 
 /* removes message with matching receipt from queue, writes to log and updates line to show the message was received. */

--- a/src/toxic.c
+++ b/src/toxic.c
@@ -947,6 +947,7 @@ static void do_toxic(Tox *m)
 
     tox_iterate(m, NULL);
     do_tox_connection(m);
+
     pthread_mutex_unlock(&Winthread.lock);
 }
 
@@ -985,9 +986,7 @@ void *thread_cqueue(void *data)
     while (true) {
         pthread_mutex_lock(&Winthread.lock);
 
-        size_t i;
-
-        for (i = 2; i < MAX_WINDOWS_NUM; ++i) {
+        for (size_t i = 2; i < MAX_WINDOWS_NUM; ++i) {
             ToxWindow *toxwin = get_window_ptr(i);
 
             if ((toxwin != NULL) && (toxwin->type == WINDOW_TYPE_CHAT)
@@ -998,7 +997,7 @@ void *thread_cqueue(void *data)
 
         pthread_mutex_unlock(&Winthread.lock);
 
-        sleep_thread(4000L);
+        sleep_thread(750000L); // 0.75 seconds
     }
 }
 


### PR DESCRIPTION
We now attempt to send all queued messages per call to cqueue_try_send() instead of just the oldest message in the queue. This speeds things up substantially.

Also fixed a very unlikely bug where the read receipt might wrap around to zero which we used as a reserved value for an unsent message

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxic/123)
<!-- Reviewable:end -->
