### PR TITLE
fix: some issues with file transfers

### DIFF
--- a/src/avatars.h
+++ b/src/avatars.h
@@ -48,5 +48,6 @@ void avatar_unset(Tox *m);
 
 void on_avatar_chunk_request(Tox *m, struct FileTransfer *ft, uint64_t position, size_t length);
 void on_avatar_file_control(Tox *m, struct FileTransfer *ft, Tox_File_Control control);
+void on_avatar_friend_connection_status(Tox *m, uint32_t friendnumber, Tox_Connection connection_status);
 
 #endif /* AVATARS_H */

--- a/src/chat.c
+++ b/src/chat.c
@@ -326,15 +326,17 @@ static void chat_pause_file_transfers(uint32_t friendnum)
 {
     ToxicFriend *friend = &Friends.list[friendnum];
 
-    size_t i;
+    for (size_t i = 0; i < MAX_FILES; ++i) {
+        struct FileTransfer *fts = &friend->file_sender[i];
 
-    for (i = 0; i < MAX_FILES; ++i) {
-        if (friend->file_sender[i].state >= FILE_TRANSFER_STARTED) {
-            friend->file_sender[i].state = FILE_TRANSFER_PAUSED;
+        if (fts->file_type == TOX_FILE_KIND_DATA && fts->state >= FILE_TRANSFER_STARTED) {
+            fts->state = FILE_TRANSFER_PAUSED;
         }
 
-        if (friend->file_receiver[i].state >= FILE_TRANSFER_STARTED) {
-            friend->file_receiver[i].state = FILE_TRANSFER_PAUSED;
+        struct FileTransfer *ftr = &friend->file_receiver[i];
+
+        if (ftr->file_type == TOX_FILE_KIND_DATA && ftr->state >= FILE_TRANSFER_STARTED) {
+            ftr->state = FILE_TRANSFER_PAUSED;
         }
     }
 }
@@ -342,18 +344,16 @@ static void chat_pause_file_transfers(uint32_t friendnum)
 /* Tries to resume broken file senders. Called when a friend comes online */
 static void chat_resume_file_senders(ToxWindow *self, Tox *m, uint32_t friendnum)
 {
-    size_t i;
-
-    for (i = 0; i < MAX_FILES; ++i) {
+    for (size_t i = 0; i < MAX_FILES; ++i) {
         struct FileTransfer *ft = &Friends.list[friendnum].file_sender[i];
 
-        if (ft->state != FILE_TRANSFER_PAUSED) {
+        if (ft->state != FILE_TRANSFER_PAUSED || ft->file_type != TOX_FILE_KIND_DATA) {
             continue;
         }
 
         Tox_Err_File_Send err;
-        ft->filenum = tox_file_send(m, friendnum, TOX_FILE_KIND_DATA, ft->file_size, ft->file_id,
-                                    (uint8_t *) ft->file_name, strlen(ft->file_name), &err);
+        ft->filenumber = tox_file_send(m, friendnum, TOX_FILE_KIND_DATA, ft->file_size, ft->file_id,
+                                       (uint8_t *) ft->file_name, strlen(ft->file_name), &err);
 
         if (err != TOX_ERR_FILE_SEND_OK) {
             char msg[MAX_STR_SIZE];
@@ -364,14 +364,14 @@ static void chat_resume_file_senders(ToxWindow *self, Tox *m, uint32_t friendnum
     }
 }
 
-static void chat_onFileChunkRequest(ToxWindow *self, Tox *m, uint32_t friendnum, uint32_t filenum, uint64_t position,
+static void chat_onFileChunkRequest(ToxWindow *self, Tox *m, uint32_t friendnum, uint32_t filenumber, uint64_t position,
                                     size_t length)
 {
     if (friendnum != self->num) {
         return;
     }
 
-    struct FileTransfer *ft = get_file_transfer_struct(friendnum, filenum);
+    struct FileTransfer *ft = get_file_transfer_struct(friendnum, filenumber);
 
     if (!ft) {
         return;
@@ -424,7 +424,7 @@ static void chat_onFileChunkRequest(ToxWindow *self, Tox *m, uint32_t friendnum,
     }
 
     Tox_Err_File_Send_Chunk err;
-    tox_file_send_chunk(m, ft->friendnum, ft->filenum, position, send_data, send_length, &err);
+    tox_file_send_chunk(m, ft->friendnumber, ft->filenumber, position, send_data, send_length, &err);
 
     free(send_data);
 
@@ -434,10 +434,9 @@ static void chat_onFileChunkRequest(ToxWindow *self, Tox *m, uint32_t friendnum,
 
     ft->position += send_length;
     ft->bps += send_length;
-    ft->last_keep_alive = get_unix_time();
 }
 
-static void chat_onFileRecvChunk(ToxWindow *self, Tox *m, uint32_t friendnum, uint32_t filenum, uint64_t position,
+static void chat_onFileRecvChunk(ToxWindow *self, Tox *m, uint32_t friendnum, uint32_t filenumber, uint64_t position,
                                  const char *data, size_t length)
 {
     UNUSED_VAR(position);
@@ -446,7 +445,7 @@ static void chat_onFileRecvChunk(ToxWindow *self, Tox *m, uint32_t friendnum, ui
         return;
     }
 
-    struct FileTransfer *ft = get_file_transfer_struct(friendnum, filenum);
+    struct FileTransfer *ft = get_file_transfer_struct(friendnum, filenumber);
 
     if (!ft) {
         return;
@@ -479,16 +478,16 @@ static void chat_onFileRecvChunk(ToxWindow *self, Tox *m, uint32_t friendnum, ui
 
     ft->bps += length;
     ft->position += length;
-    ft->last_keep_alive = get_unix_time();
 }
 
-static void chat_onFileControl(ToxWindow *self, Tox *m, uint32_t friendnum, uint32_t filenum, Tox_File_Control control)
+static void chat_onFileControl(ToxWindow *self, Tox *m, uint32_t friendnum, uint32_t filenumber,
+                               Tox_File_Control control)
 {
     if (friendnum != self->num) {
         return;
     }
 
-    struct FileTransfer *ft = get_file_transfer_struct(friendnum, filenum);
+    struct FileTransfer *ft = get_file_transfer_struct(friendnum, filenumber);
 
     if (!ft) {
         return;
@@ -498,8 +497,6 @@ static void chat_onFileControl(ToxWindow *self, Tox *m, uint32_t friendnum, uint
 
     switch (control) {
         case TOX_FILE_CONTROL_RESUME: {
-            ft->last_keep_alive = get_unix_time();
-
             /* transfer is accepted */
             if (ft->state == FILE_TRANSFER_PENDING) {
                 ft->state = FILE_TRANSFER_STARTED;
@@ -534,12 +531,12 @@ static void chat_onFileControl(ToxWindow *self, Tox *m, uint32_t friendnum, uint
  *
  * Returns true if resume is successful.
  */
-static bool chat_resume_broken_ft(ToxWindow *self, Tox *m, uint32_t friendnum, uint32_t filenum)
+static bool chat_resume_broken_ft(ToxWindow *self, Tox *m, uint32_t friendnum, uint32_t filenumber)
 {
     char msg[MAX_STR_SIZE];
     uint8_t file_id[TOX_FILE_ID_LENGTH];
 
-    if (!tox_file_get_file_id(m, friendnum, filenum, file_id, NULL)) {
+    if (!tox_file_get_file_id(m, friendnum, filenumber, file_id, NULL)) {
         return false;
     }
 
@@ -555,9 +552,8 @@ static bool chat_resume_broken_ft(ToxWindow *self, Tox *m, uint32_t friendnum, u
         }
 
         if (memcmp(ft->file_id, file_id, TOX_FILE_ID_LENGTH) == 0) {
-            ft->filenum = filenum;
+            ft->filenumber = filenumber;
             ft->state = FILE_TRANSFER_STARTED;
-            ft->last_keep_alive = get_unix_time();
             resuming = true;
             break;
         }
@@ -567,11 +563,11 @@ static bool chat_resume_broken_ft(ToxWindow *self, Tox *m, uint32_t friendnum, u
         return false;
     }
 
-    if (!tox_file_seek(m, ft->friendnum, ft->filenum, ft->position, NULL)) {
+    if (!tox_file_seek(m, ft->friendnumber, ft->filenumber, ft->position, NULL)) {
         goto on_error;
     }
 
-    if (!tox_file_control(m, ft->friendnum, ft->filenum, TOX_FILE_CONTROL_RESUME, NULL)) {
+    if (!tox_file_control(m, ft->friendnumber, ft->filenumber, TOX_FILE_CONTROL_RESUME, NULL)) {
         goto on_error;
     }
 
@@ -615,7 +611,7 @@ static bool valid_file_name(const char *filename, size_t length)
     return true;
 }
 
-static void chat_onFileRecv(ToxWindow *self, Tox *m, uint32_t friendnum, uint32_t filenum, uint64_t file_size,
+static void chat_onFileRecv(ToxWindow *self, Tox *m, uint32_t friendnum, uint32_t filenumber, uint64_t file_size,
                             const char *filename, size_t name_length)
 {
     if (self->num != friendnum) {
@@ -623,14 +619,14 @@ static void chat_onFileRecv(ToxWindow *self, Tox *m, uint32_t friendnum, uint32_
     }
 
     /* first check if we need to resume a broken transfer */
-    if (chat_resume_broken_ft(self, m, friendnum, filenum)) {
+    if (chat_resume_broken_ft(self, m, friendnum, filenumber)) {
         return;
     }
 
-    struct FileTransfer *ft = new_file_transfer(self, friendnum, filenum, FILE_TRANSFER_RECV, TOX_FILE_KIND_DATA);
+    struct FileTransfer *ft = new_file_transfer(self, friendnum, filenumber, FILE_TRANSFER_RECV, TOX_FILE_KIND_DATA);
 
     if (!ft) {
-        tox_file_control(m, friendnum, filenum, TOX_FILE_CONTROL_CANCEL, NULL);
+        tox_file_control(m, friendnum, filenumber, TOX_FILE_CONTROL_CANCEL, NULL);
         line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0,
                       "File transfer request failed: Too many concurrent file transfers.");
         return;
@@ -702,7 +698,7 @@ static void chat_onFileRecv(ToxWindow *self, Tox *m, uint32_t friendnum, uint32_
     ft->file_size = file_size;
     snprintf(ft->file_path, sizeof(ft->file_path), "%s", file_path);
     snprintf(ft->file_name, sizeof(ft->file_name), "%s", filename);
-    tox_file_get_file_id(m, friendnum, filenum, ft->file_id, NULL);
+    tox_file_get_file_id(m, friendnum, filenumber, ft->file_id, NULL);
 
     free(file_path);
 

--- a/src/chat_commands.c
+++ b/src/chat_commands.c
@@ -183,7 +183,7 @@ void cmd_savefile(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv
     }
 
     Tox_Err_File_Control err;
-    tox_file_control(m, self->num, ft->filenum, TOX_FILE_CONTROL_RESUME, &err);
+    tox_file_control(m, self->num, ft->filenumber, TOX_FILE_CONTROL_RESUME, &err);
 
     if (err != TOX_ERR_FILE_CONTROL_OK) {
         goto on_recv_error;

--- a/src/file_transfers.h
+++ b/src/file_transfers.h
@@ -51,18 +51,16 @@ struct FileTransfer {
     ToxWindow *window;
     FILE *file;
     FILE_TRANSFER_STATE state;
-    FILE_TRANSFER_DIRECTION direction;
     uint8_t file_type;
     char file_name[TOX_MAX_FILENAME_LENGTH + 1];
     char file_path[PATH_MAX + 1];    /* Not used by senders */
     double   bps;
-    uint32_t filenum;
-    uint32_t friendnum;
+    uint32_t filenumber;
+    uint32_t friendnumber;
     size_t   index;
     uint64_t file_size;
     uint64_t position;
     time_t   last_line_progress;   /* The last time we updated the progress bar */
-    time_t   last_keep_alive;  /* The last time we sent or received data */
     uint32_t line_id;
     uint8_t  file_id[TOX_FILE_ID_LENGTH];
 };
@@ -75,24 +73,24 @@ void init_progress_bar(char *progline);
 void print_progress_bar(ToxWindow *self, double pct_done, double bps, uint32_t line_id);
 
 /* refreshes active file transfer status bars. */
-void refresh_file_transfer_progress(ToxWindow *self, uint32_t friendnum);
+void refresh_file_transfer_progress(ToxWindow *self, uint32_t friendnumber);
 
-/* Returns a pointer to friendnum's FileTransfer struct associated with filenum.
- * Returns NULL if filenum is invalid.
+/* Returns a pointer to friendnumber's FileTransfer struct associated with filenumber.
+ * Returns NULL if filenumber is invalid.
  */
-struct FileTransfer *get_file_transfer_struct(uint32_t friendnum, uint32_t filenum);
+struct FileTransfer *get_file_transfer_struct(uint32_t friendnumber, uint32_t filenumber);
 
 
 /* Returns a pointer to the FileTransfer struct associated with index with the direction specified.
  * Returns NULL on failure.
  */
-struct FileTransfer *get_file_transfer_struct_index(uint32_t friendnum, uint32_t index,
+struct FileTransfer *get_file_transfer_struct_index(uint32_t friendnumber, uint32_t index,
         FILE_TRANSFER_DIRECTION direction);
 
 /* Initializes an unused file transfer and returns its pointer.
  * Returns NULL on failure.
  */
-struct FileTransfer *new_file_transfer(ToxWindow *window, uint32_t friendnum, uint32_t filenum,
+struct FileTransfer *new_file_transfer(ToxWindow *window, uint32_t friendnumber, uint32_t filenumber,
                                        FILE_TRANSFER_DIRECTION direction, uint8_t type);
 
 /* Closes file transfer ft.
@@ -103,8 +101,11 @@ struct FileTransfer *new_file_transfer(ToxWindow *window, uint32_t friendnum, ui
 void close_file_transfer(ToxWindow *self, Tox *m, struct FileTransfer *ft, int CTRL, const char *message,
                          Notification sound_type);
 
-/* Kills all active file transfers for friendnum */
-void kill_all_file_transfers_friend(Tox *m, uint32_t friendnum);
+/* Kills active outgoing avatar file transfers for friendnumber */
+void kill_avatar_file_transfers_friend(Tox *m, uint32_t friendnumber);
+
+/* Kills all active file transfers for friendnumber */
+void kill_all_file_transfers_friend(Tox *m, uint32_t friendnumber);
 
 void kill_all_file_transfers(Tox *m);
 

--- a/src/windows.c
+++ b/src/windows.c
@@ -66,6 +66,8 @@ void on_friend_connection_status(Tox *m, uint32_t friendnumber, Tox_Connection c
 {
     UNUSED_VAR(userdata);
 
+    on_avatar_friend_connection_status(m, friendnumber, connection_status);
+
     for (uint8_t i = 0; i < MAX_WINDOWS_NUM; ++i) {
         if (windows[i] != NULL && windows[i]->onConnectionChange != NULL) {
             windows[i]->onConnectionChange(windows[i], m, friendnumber, connection_status);


### PR DESCRIPTION
- Fix bug causing failed avatar transfers to be sent as normal file transfers when a friend goes offline and comes back online
- Remove some unused members of the FileTransfer struct
- Rename filenum -> filenumber and friendnum -> friendnumber

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxic/126)
<!-- Reviewable:end -->
