### PR TITLE
feat: Refactor/improve logging

### DIFF
--- a/src/conference.h
+++ b/src/conference.h
@@ -27,8 +27,9 @@
 #include "windows.h"
 
 #define SIDEBAR_WIDTH 16
-#define MAX_CONFERENCE_NUM MAX_WINDOWS_NUM - 2
+#define MAX_CONFERENCE_NUM (MAX_WINDOWS_NUM - 2)
 #define CONFERENCE_EVENT_WAIT 3
+#define CONFERENCE_MAX_TITLE_LENGTH TOX_MAX_NAME_LENGTH
 
 typedef struct ConferencePeer {
     bool       active;
@@ -64,6 +65,9 @@ typedef struct {
     int side_pos;    /* current position of the sidebar - used for scrolling up and down */
     time_t start_time;
 
+    char title[CONFERENCE_MAX_TITLE_LENGTH + 1];
+    size_t title_length;
+
     ConferencePeer *peer_list;
     uint32_t max_idx;
 
@@ -79,10 +83,14 @@ typedef struct {
 /* Frees all Toxic associated data structures for a conference (does not call tox_conference_delete() ) */
 void free_conference(ToxWindow *self, uint32_t conferencenum);
 
-int init_conference_win(Tox *m, uint32_t conferencenum, uint8_t type, const char *title, size_t title_length);
+int init_conference_win(Tox *m, uint32_t conferencenum, uint8_t type, const char *title, size_t length);
 
 /* destroys and re-creates conference window with or without the peerlist */
 void redraw_conference_win(ToxWindow *self);
+
+void conference_set_title(ToxWindow *self, uint32_t conferencesnum, const char *title, size_t length);
+void conference_rename_log_path(Tox *m, uint32_t conferencenum, const char *new_title);
+int conference_enable_logging(ToxWindow *self, Tox *m, uint32_t conferencenum, struct chatlog *log);
 
 /* Puts `(NameListEntry *)`s in `entries` for each matched peer, up to a maximum
  * of `maxpeers`.

--- a/src/friendlist.c
+++ b/src/friendlist.c
@@ -453,7 +453,9 @@ static void friendlist_onNickChange(ToxWindow *self, Tox *m, uint32_t num, const
     tox_self_get_address(m, (uint8_t *) myid);
 
     if (strcmp(oldname, newnamecpy) != 0) {
-        rename_logfile(oldname, newnamecpy, myid, Friends.list[num].pub_key, Friends.list[num].chatwin);
+        if (rename_logfile(oldname, newnamecpy, myid, Friends.list[num].pub_key, Friends.list[num].chatwin) != 0) {
+            fprintf(stderr, "Failed to rename friend chat log from `%s` to `%s`\n", oldname, newnamecpy);
+        }
     }
 
     sort_friendlist_index();

--- a/src/global_commands.c
+++ b/src/global_commands.c
@@ -434,21 +434,7 @@ void cmd_log(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[MAX
     const char *swch = argv[1];
 
     if (!strcmp(swch, "1") || !strcmp(swch, "on")) {
-        char myid[TOX_ADDRESS_SIZE];
-        tox_self_get_address(m, (uint8_t *) myid);
-
-        int log_ret = -1;
-
-        if (self->type == WINDOW_TYPE_CHAT) {
-            Friends.list[self->num].logging_on = true;
-            log_ret = log_enable(self->name, myid, Friends.list[self->num].pub_key, log, LOG_CHAT);
-        } else if (self->type == WINDOW_TYPE_PROMPT) {
-            log_ret = log_enable(self->name, myid, NULL, log, LOG_PROMPT);
-        } else if (self->type == WINDOW_TYPE_CONFERENCE) {
-            log_ret = log_enable(self->name, myid, NULL, log, LOG_CONFERENCE);
-        }
-
-        msg = log_ret == 0 ? "Logging enabled." : "Warning: Log failed to initialize.";
+        msg = log_enable(log) == 0 ? "Logging enabled." : "Warning: Failed to enable log.";
         line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, msg);
         return;
     } else if (!strcmp(swch, "0") || !strcmp(swch, "off")) {

--- a/src/log.h
+++ b/src/log.h
@@ -30,30 +30,43 @@ struct chatlog {
     bool log_on;    /* specific to current chat window */
 };
 
-typedef enum {
-    LOG_CONFERENCE,
-    LOG_PROMPT,
-    LOG_CHAT,
+typedef enum LOG_TYPE {
+    LOG_TYPE_PROMPT,
+    LOG_TYPE_CHAT,
 } LOG_TYPE;
+
+/* Initializes a log. This function must be called before any other logging operations.
+ *
+ * Return 0 on success.
+ * Return -1 on failure.
+ */
+int log_init(struct chatlog *log, const char *name, const char *selfkey, const char *otherkey, LOG_TYPE type);
 
 /* formats/writes line to log file */
 void write_to_log(const char *msg, const char *name, struct chatlog *log, bool event);
 
-/* enables logging for specified log and creates/fetches file if necessary.
+/* enables logging for specified log.
  *
  * Returns 0 on success.
  * Returns -1 on failure.
  */
-int log_enable(char *name, const char *selfkey, const char *otherkey, struct chatlog *log, int logtype);
+int log_enable(struct chatlog *log);
 
 /* disables logging for specified log and closes file */
 void log_disable(struct chatlog *log);
 
-/* Loads previous history from chat log */
-void load_chat_history(ToxWindow *self, struct chatlog *log);
+/* Loads chat log history and prints it to `self` window.
+ *
+ * Return 0 on success or if log file doesn't exist.
+ * Return -1 on failure.
+ */
+int load_chat_history(ToxWindow *self, struct chatlog *log);
 
-/* renames chatlog file replacing src with dest.
-   Returns 0 on success or if no log exists, -1 on failure. */
-int rename_logfile(char *src, char *dest, const char *selfkey, const char *otherkey, int winnum);
+/* Renames chatlog file `src` to `dest`.
+ *
+ * Return 0 on success or if no log exists.
+ * Return -1 on failure.
+ */
+int rename_logfile(const char *src, const char *dest, const char *selfkey, const char *otherkey, int winnum);
 
 #endif /* LOG_H */

--- a/src/prompt.c
+++ b/src/prompt.c
@@ -554,6 +554,25 @@ static void print_welcome_msg(ToxWindow *self)
     line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "");
 }
 
+static void prompt_init_log(ToxWindow *self, Tox *m, const char *self_name)
+{
+    ChatContext *ctx = self->chatwin;
+
+    char myid[TOX_ADDRESS_SIZE];
+    tox_self_get_address(m, (uint8_t *) myid);
+
+    if (log_init(ctx->log, self->name, myid, NULL, LOG_TYPE_PROMPT) != 0) {
+        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Warning: Log failed to initialize.");
+        return;
+    }
+
+    if (user_settings->autolog == AUTOLOG_ON) {
+        if (log_enable(ctx->log) == -1) {
+            line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Warning: Failed to enable log.");
+        }
+    }
+}
+
 static void prompt_onInit(ToxWindow *self, Tox *m)
 {
     curs_set(1);
@@ -577,14 +596,7 @@ static void prompt_onInit(ToxWindow *self, Tox *m)
 
     line_info_init(ctx->hst);
 
-    if (user_settings->autolog == AUTOLOG_ON) {
-        char myid[TOX_ADDRESS_SIZE];
-        tox_self_get_address(m, (uint8_t *) myid);
-
-        if (log_enable(self->name, myid, NULL, ctx->log, LOG_PROMPT) == -1) {
-            line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Warning: Log failed to initialize.");
-        }
-    }
+    prompt_init_log(self, m, self->name);
 
     scrollok(ctx->history, 0);
     wmove(self->window, y2 - CURS_Y_OFFSET, 0);


### PR DESCRIPTION
The conference logging implementation was written a long time ago when groupchats didn't have a unique identifier provided by the toxcore API, so there was no easy way to keep track of unique log names across restarts or title changes.

- Conference logging now behaves the same as 1-on-1 chats: Instead of creating a new log file every time we restat the client we use the unique conference ID to keep track of path names. This also allows us to load history for saved groups on client startup

- Added a log init function / general code refactor.

- Fixed a bug that caused log files to be created even when logging is disabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxic/134)
<!-- Reviewable:end -->
