### PR TITLE
feat: Add config settings for audio channels

### DIFF
--- a/doc/toxic.conf.5
+++ b/doc/toxic.conf.5
@@ -2,12 +2,12 @@
 .\"     Title: toxic.conf
 .\"    Author: [see the "AUTHORS" section]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 2018-10-27
+.\"      Date: 2020-05-07
 .\"    Manual: Toxic Manual
 .\"    Source: toxic __VERSION__
 .\"  Language: English
 .\"
-.TH "TOXIC\&.CONF" "5" "2018\-10\-27" "toxic __VERSION__" "Toxic Manual"
+.TH "TOXIC\&.CONF" "5" "2020\-05\-07" "toxic __VERSION__" "Toxic Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -135,7 +135,7 @@ Maximum lines for chat window history\&. Integer value\&. (for example: 700)
 .PP
 \fBnotification_timeout\fR
 .RS 4
-Time in milliseconds to display a notification\&. (for example: 3000)
+Time in milliseconds to display a notification\&. Integer value\&. (for example: 3000)
 .RE
 .PP
 \fBline_join\fR
@@ -219,7 +219,17 @@ Audio output device\&. Integer value\&. Number corresponds to
 .PP
 \fBVAD_threshold\fR
 .RS 4
-Voice Activity Detection threshold\&. Float value\&. Recommended values are 1\&.0-40\&.0
+Voice Activity Detection threshold\&. Float value\&. Recommended values are 1\&.0\-40\&.0
+.RE
+.PP
+\fBconference_audio_channels\fR
+.RS 4
+Number of channels for conference audio broadcast\&. Integer value\&. 1 (mono) or 2 (stereo)
+.RE
+.PP
+\fBchat_audio_channels\fR
+.RS 4
+Number of channels for 1\-on\-1 audio broadcast\&. Integer value\&. 1 (mono) or 2 (stereo)
 .RE
 .RE
 .PP

--- a/doc/toxic.conf.5.asc
+++ b/doc/toxic.conf.5.asc
@@ -139,6 +139,12 @@ OPTIONS
         Voice Activity Detection threshold.  Float value. Recommended values are
         1.0-40.0
 
+    *conference_audio_channels*;;
+        Number of channels for conference audio broadcast. Integer value. 1 (mono) or 2 (stereo)
+
+    *chat_audio_channels*;;
+        Number of channels for 1-on-1 audio broadcast. Integer value. 1 (mono) or 2 (stereo)
+
 *tox*::
     Configuration related to paths.
 

--- a/misc/toxic.conf.example
+++ b/misc/toxic.conf.example
@@ -84,6 +84,12 @@ audio = {
 
   // default VAD threshold; float (recommended values are 1.0-40.0)
   VAD_threshold=5.0;
+
+  // Number of channels to use for conference audio broadcasts; 1 for mono, 2 for stereo.
+  conference_audio_channels=1;
+
+  // Number of channels to use for 1-on-1 audio broadcasts; 1 for mono, 2 for stereo.
+  chat_audio_channels=2;
 };
 
 tox = {

--- a/src/audio_call.c
+++ b/src/audio_call.c
@@ -29,6 +29,7 @@
 #include "line_info.h"
 #include "misc_tools.h"
 #include "notify.h"
+#include "settings.h"
 #include "toxic.h"
 #include "windows.h"
 
@@ -64,6 +65,7 @@ extern ToxWindow *windows[MAX_WINDOWS_NUM];
 
 struct CallControl CallControl;
 
+extern struct user_settings *user_settings;
 extern struct Winthread Winthread;
 
 void on_call(ToxAV *av, uint32_t friend_number, bool audio_enabled, bool video_enabled,
@@ -103,7 +105,7 @@ ToxAV *init_audio(ToxWindow *self, Tox *tox)
     CallControl.default_audio_bit_rate = 64;
     CallControl.audio_sample_rate = 48000;
     CallControl.audio_frame_duration = 20;
-    CallControl.audio_channels = 1;
+    CallControl.audio_channels = user_settings->chat_audio_channels;
 
     CallControl.video_enabled = false;
     CallControl.default_video_bit_rate = 0;

--- a/src/conference.c
+++ b/src/conference.c
@@ -1159,7 +1159,6 @@ static ToxWindow *new_conference_chat(uint32_t conferencenum)
 
 #define CONFAV_SAMPLE_RATE 48000
 #define CONFAV_FRAME_DURATION 20
-#define CONFAV_AUDIO_CHANNELS 2
 #define CONFAV_SAMPLES_PER_FRAME (CONFAV_SAMPLE_RATE * CONFAV_FRAME_DURATION / 1000)
 
 void audio_conference_callback(void *tox, uint32_t conferencenum, uint32_t peernum, const int16_t *pcm,
@@ -1198,10 +1197,12 @@ static void conference_read_device_callback(const int16_t *captured, uint32_t si
 
     conferences[audio_input_callback_data->conferencenum].last_sent_audio = get_unix_time();
 
+    int channels = user_settings->conference_audio_channels;
+
     toxav_group_send_audio(audio_input_callback_data->tox,
                            audio_input_callback_data->conferencenum,
                            captured, CONFAV_SAMPLES_PER_FRAME,
-                           CONFAV_AUDIO_CHANNELS, CONFAV_SAMPLE_RATE);
+                           channels, CONFAV_SAMPLE_RATE);
 }
 
 bool init_conference_audio_input(Tox *tox, uint32_t conferencenum)
@@ -1215,9 +1216,11 @@ bool init_conference_audio_input(Tox *tox, uint32_t conferencenum)
     const AudioInputCallbackData audio_input_callback_data = { tox, conferencenum };
     chat->audio_input_callback_data = audio_input_callback_data;
 
+    int channels = user_settings->conference_audio_channels;
+
     bool success = (open_input_device(&chat->audio_in_idx,
                                       conference_read_device_callback, &chat->audio_input_callback_data, true,
-                                      CONFAV_SAMPLE_RATE, CONFAV_FRAME_DURATION, CONFAV_AUDIO_CHANNELS)
+                                      CONFAV_SAMPLE_RATE, CONFAV_FRAME_DURATION, channels)
                     == de_None);
 
     chat->audio_enabled = success;

--- a/src/settings.c
+++ b/src/settings.c
@@ -205,11 +205,15 @@ static const struct audio_strings {
     const char *input_device;
     const char *output_device;
     const char *VAD_threshold;
+    const char *conference_audio_channels;
+    const char *chat_audio_channels;
 } audio_strings = {
     "audio",
     "input_device",
     "output_device",
     "VAD_threshold",
+    "conference_audio_channels",
+    "chat_audio_channels",
 };
 
 static void audio_defaults(struct user_settings *settings)
@@ -217,6 +221,8 @@ static void audio_defaults(struct user_settings *settings)
     settings->audio_in_dev = 0;
     settings->audio_out_dev = 0;
     settings->VAD_threshold = 5.0;
+    settings->conference_audio_channels = 1;
+    settings->chat_audio_channels = 2;
 }
 #endif
 
@@ -506,6 +512,13 @@ int settings_load(struct user_settings *s, const char *patharg)
         s->audio_out_dev = s->audio_out_dev < 0 || s->audio_out_dev > MAX_DEVICES ? 0 : s->audio_out_dev;
 
         config_setting_lookup_float(setting, audio_strings.VAD_threshold, &s->VAD_threshold);
+
+        config_setting_lookup_int(setting, audio_strings.conference_audio_channels, &s->conference_audio_channels);
+        s->conference_audio_channels = s->conference_audio_channels <= 0
+                                       || s->conference_audio_channels > 2 ? 1 : s->conference_audio_channels;
+
+        config_setting_lookup_int(setting, audio_strings.chat_audio_channels, &s->chat_audio_channels);
+        s->chat_audio_channels = s->chat_audio_channels <= 0 || s->chat_audio_channels > 2 ? 2 : s->chat_audio_channels;
     }
 
 #endif

--- a/src/settings.h
+++ b/src/settings.h
@@ -85,6 +85,8 @@ struct user_settings {
     int audio_in_dev;
     int audio_out_dev;
     double VAD_threshold;
+    int conference_audio_channels;
+    int chat_audio_channels;
 #endif
 };
 


### PR DESCRIPTION
This allows us to configure chat/conference channels independently. The default settings prioritize quality for 1-on-1 chats, and bandwidth for conferences.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxic/136)
<!-- Reviewable:end -->
