### PR TITLE
cleanup: Some code cleanup and fixes

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -175,36 +175,36 @@ void cmd_run(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[MAX
 
 void invoke_autoruns(WINDOW *window, ToxWindow *self)
 {
-    struct dirent *dir;
-    char    abspath_buf[PATH_MAX + 1], err_buf[PATH_MAX + 1];
-    size_t  path_len;
-    DIR    *d;
-    FILE   *fp;
+    char abspath_buf[PATH_MAX + 256];
+    char err_buf[PATH_MAX + 128];
 
     if (user_settings->autorun_path[0] == '\0') {
         return;
     }
 
-    d = opendir(user_settings->autorun_path);
+    DIR *d = opendir(user_settings->autorun_path);
 
     if (d == NULL) {
-        snprintf(err_buf, PATH_MAX + 1, "Autorun path does not exist: %s", user_settings->autorun_path);
+        snprintf(err_buf, sizeof(err_buf), "Autorun path does not exist: %s", user_settings->autorun_path);
         api_display(err_buf);
         return;
     }
 
+    struct dirent *dir = NULL;
+
     cur_window  = window;
+
     self_window = self;
 
     while ((dir = readdir(d)) != NULL) {
-        path_len = strlen(dir->d_name);
+        size_t path_len = strlen(dir->d_name);
 
         if (!strcmp(dir->d_name + path_len - 3, ".py")) {
-            snprintf(abspath_buf, PATH_MAX + 1, "%s%s", user_settings->autorun_path, dir->d_name);
-            fp = fopen(abspath_buf, "r");
+            snprintf(abspath_buf, sizeof(abspath_buf), "%s%s", user_settings->autorun_path, dir->d_name);
+            FILE *fp = fopen(abspath_buf, "r");
 
             if (fp == NULL) {
-                snprintf(err_buf, PATH_MAX + 1, "Invalid path: %s", abspath_buf);
+                snprintf(err_buf, sizeof(err_buf), "Invalid path: %s", abspath_buf);
                 api_display(err_buf);
                 continue;
             }

--- a/src/audio_call.c
+++ b/src/audio_call.c
@@ -916,7 +916,7 @@ void stop_current_call(ToxWindow *self)
  */
 static void realloc_calls(uint32_t n)
 {
-    if (n <= 0) {
+    if (n == 0) {
         free(CallControl.calls);
         CallControl.calls = NULL;
         return;

--- a/src/chat.c
+++ b/src/chat.c
@@ -504,8 +504,6 @@ static void chat_onFileControl(ToxWindow *self, Tox *m, uint32_t friendnum, uint
         return;
     }
 
-    char msg[MAX_STR_SIZE];
-
     switch (control) {
         case TOX_FILE_CONTROL_RESUME: {
             /* transfer is accepted */
@@ -531,6 +529,7 @@ static void chat_onFileControl(ToxWindow *self, Tox *m, uint32_t friendnum, uint
         }
 
         case TOX_FILE_CONTROL_CANCEL: {
+            char msg[MAX_STR_SIZE];
             snprintf(msg, sizeof(msg), "File transfer for '%s' was aborted.", ft->file_name);
             close_file_transfer(self, m, ft, -1, msg, notif_error);
             break;

--- a/src/friendlist.c
+++ b/src/friendlist.c
@@ -807,7 +807,7 @@ static void delete_blocked_friend(uint32_t bnum)
 /* deletes contact from friendlist and puts in blocklist */
 void block_friend(Tox *m, uint32_t fnum)
 {
-    if (Friends.num_friends <= 0) {
+    if (Friends.num_friends == 0) {
         return;
     }
 

--- a/src/global_commands.c
+++ b/src/global_commands.c
@@ -389,9 +389,6 @@ void cmd_conference(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*ar
         line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Audio support disabled by compile-time option.");
         return;
 #endif
-    } else {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Unknown conference type %d", type);
-        return;
     }
 
     if (init_conference_win(m, conferencenum, type, NULL, 0) == -1) {

--- a/src/log.c
+++ b/src/log.c
@@ -358,8 +358,15 @@ int rename_logfile(const char *src, const char *dest, const char *selfkey, const
     }
 
     if (file_exists(newpath)) {
-        if (remove(oldpath) != 0) {
-            fprintf(stderr, "Failed to remove old path `%s`\n", oldpath);
+        char new_backup[MAX_STR_SIZE + 4];
+        snprintf(new_backup, sizeof(new_backup), "%s.old", newpath);
+
+        if (file_exists(new_backup)) {
+            goto on_error;
+        }
+
+        if (rename(newpath, new_backup) != 0) {
+            goto on_error;
         }
     } else {
         if (rename(oldpath, newpath) != 0) {

--- a/src/log.c
+++ b/src/log.c
@@ -368,10 +368,10 @@ int rename_logfile(const char *src, const char *dest, const char *selfkey, const
         if (rename(newpath, new_backup) != 0) {
             goto on_error;
         }
-    } else {
-        if (rename(oldpath, newpath) != 0) {
-            goto on_error;
-        }
+    }
+
+    if (rename(oldpath, newpath) != 0) {
+        goto on_error;
     }
 
     if (log != NULL) {

--- a/src/python_api.c
+++ b/src/python_api.c
@@ -114,25 +114,23 @@ static PyObject *python_api_get_status_message(PyObject *self, PyObject *args)
 
 static PyObject *python_api_get_all_friends(PyObject *self, PyObject *args)
 {
-    size_t       i, ii;
     FriendsList  friends;
-    PyObject    *cur, *ret;
-    char         pubkey_buf[TOX_PUBLIC_KEY_SIZE * 2 + 1];
+    char pubkey_buf[TOX_PUBLIC_KEY_SIZE * 2 + 1];
 
     if (!PyArg_ParseTuple(args, "")) {
         return NULL;
     }
 
     friends = api_get_friendslist();
-    ret     = PyList_New(0);
+    PyObject *ret = PyList_New(0);
 
-    for (i = 0; i < friends.num_friends; i++) {
-        for (ii = 0; ii < TOX_PUBLIC_KEY_SIZE; ii++) {
+    for (size_t i = 0; i < friends.num_friends; i++) {
+        for (size_t ii = 0; ii < TOX_PUBLIC_KEY_SIZE; ii++) {
             snprintf(pubkey_buf + ii * 2, 3, "%02X", friends.list[i].pub_key[ii] & 0xff);
         }
 
         pubkey_buf[TOX_PUBLIC_KEY_SIZE * 2] = '\0';
-        cur = Py_BuildValue("(s,s)", friends.list[i].name, pubkey_buf);
+        PyObject *cur = Py_BuildValue("(s,s)", friends.list[i].name, pubkey_buf);
         PyList_Append(ret, cur);
     }
 
@@ -264,14 +262,14 @@ PyMODINIT_FUNC PyInit_toxic_api(void)
 
 void terminate_python(void)
 {
-    struct python_registered_func *cur, *old;
-
     if (python_commands.name != NULL) {
         free(python_commands.name);
     }
 
+    struct python_registered_func *cur = NULL;
+
     for (cur = python_commands.next; cur != NULL;) {
-        old = cur;
+        struct python_registered_func *old = cur;
         cur = cur->next;
         free(old->name);
         free(old);

--- a/src/xtra.c
+++ b/src/xtra.c
@@ -235,10 +235,11 @@ void *event_loop(void *p)
     UNUSED_VAR(p); /* DINDUNOTHIN */
 
     XEvent event;
-    int pending;
 
     while (Xtra.display) {
         /* NEEDMOEVENTSFODEMPROGRAMS */
+
+        int pending = 0;
 
         XLockDisplay(Xtra.display);
 


### PR DESCRIPTION
- Create backup of duplicate log file instead of deleting it (this case should never occur, but just in case it does it's good to handle it without any data loss)
- Fix race condition in `draw_peer()`
- Handle `realloc_peer_list()` error
- Remove dead code in `cmd_conference()`
- Reduce scope of a few variables
- Fix possible buffer truncation in api.c

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxic/139)
<!-- Reviewable:end -->
