### PR TITLE
feat: Some UI improvements

### DIFF
--- a/src/friendlist.c
+++ b/src/friendlist.c
@@ -1378,6 +1378,6 @@ ToxWindow *new_friendlist(void)
     }
 
     ret->help = help;
-    strcpy(ret->name, "contacts");
+    strcpy(ret->name, "Contacts");
     return ret;
 }

--- a/src/misc_tools.c
+++ b/src/misc_tools.c
@@ -584,11 +584,7 @@ void set_window_title(ToxWindow *self, const char *title, int len)
 
     char cpy[TOXIC_MAX_NAME_LENGTH + 1];
 
-    if (self->type == WINDOW_TYPE_CONFERENCE) { /* keep conferencenumber in title */
-        snprintf(cpy, sizeof(cpy), "%u %s", self->num, title);
-    } else {
-        snprintf(cpy, sizeof(cpy), "%s", title);
-    }
+    snprintf(cpy, sizeof(cpy), "%s", title);
 
     if (len > MAX_WINDOW_NAME_LENGTH) {
         strcpy(&cpy[MAX_WINDOW_NAME_LENGTH - 3], "...");

--- a/src/prompt.c
+++ b/src/prompt.c
@@ -623,7 +623,7 @@ ToxWindow *new_prompt(void)
     ret->onConnectionChange = &prompt_onConnectionChange;
     ret->onFriendRequest = &prompt_onFriendRequest;
 
-    strcpy(ret->name, "home");
+    strcpy(ret->name, "Home");
 
     ChatContext *chatwin = calloc(1, sizeof(ChatContext));
     StatusBar *stb = calloc(1, sizeof(StatusBar));

--- a/src/toxic.c
+++ b/src/toxic.c
@@ -1501,6 +1501,7 @@ int main(int argc, char **argv)
 
     pthread_mutex_lock(&Winthread.lock);
     print_init_messages(prompt);
+    set_active_window_index(0);
     pthread_mutex_unlock(&Winthread.lock);
 
     cleanup_init_messages();

--- a/src/windows.c
+++ b/src/windows.c
@@ -494,7 +494,7 @@ void on_window_resize(void)
     }
 }
 
-static void draw_window_tab(ToxWindow *toxwin)
+static void draw_window_tab(ToxWindow *toxwin, bool active_window)
 {
     pthread_mutex_lock(&Winthread.lock);
 
@@ -505,7 +505,12 @@ static void draw_window_tab(ToxWindow *toxwin)
     pthread_mutex_unlock(&Winthread.lock);
 
     clrtoeol();
-    printw(" [%s]", toxwin->name);
+
+    if (active_window || toxwin->index <= 1) {
+        printw(" [%s]", toxwin->name);
+    } else {
+        printw(" [%u]", toxwin->index - 1);
+    }
 
     pthread_mutex_lock(&Winthread.lock);
 
@@ -540,7 +545,9 @@ static void draw_bar(void)
             continue;
         }
 
-        if (i == active_window_index) {
+        bool active_window = i == active_window_index;
+
+        if (active_window) {
 
 #ifdef URXVT_FIX
             attron(A_BOLD | COLOR_PAIR(GREEN));
@@ -550,9 +557,9 @@ static void draw_bar(void)
             attron(A_BOLD);
         }
 
-        draw_window_tab(windows[i]);
+        draw_window_tab(windows[i], active_window);
 
-        if (i == active_window_index) {
+        if (active_window) {
 
 #ifdef URXVT_FIX
             attroff(A_BOLD | COLOR_PAIR(GREEN));

--- a/src/windows.h
+++ b/src/windows.h
@@ -36,7 +36,7 @@
 
 #include "toxic.h"
 
-#define MAX_WINDOWS_NUM 16
+#define MAX_WINDOWS_NUM 20
 #define MAX_WINDOW_NAME_LENGTH 22
 #define CURS_Y_OFFSET 1    /* y-axis cursor offset for chat contexts */
 #define CHATBOX_HEIGHT 2


### PR DESCRIPTION
- Bottom tab now only shows indices of active chat windows unless focused (this mostly remedies the issue of tabs disappearing off the right of the screen when you have numerous chats open)
- Always focus Home screen on startup instead of the last loaded conference
- Conference tab names are no longer prefixed with the conference number
- Home and Contact tab names are now capitalized

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxic/141)
<!-- Reviewable:end -->
