### PR TITLE
chore: Add release and LLVM asan build options

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -59,6 +59,8 @@ Run `make doc` in the build directory after editing the asciidoc files to regene
   * `DISABLE_QRPNG` → Disable support for exporting QR as PNG
   * `DISABLE_DESKTOP_NOTIFY=1` → Disable desktop notifications support
   * `ENABLE_PYTHON=1` → Build toxic with Python scripting support
+  * `ENABLE_RELEASE=1` → Build toxic without debug symbols and with full compiler optimizations
+  * `ENABLE_ASAN=1` → Build toxic with LLVM Address Sanitizer enabled
 
 * `DESTDIR=""` Specifies the base install directory for binaries and data files (e.g.: DESTDIR="/tmp/build/pkg")
 

--- a/cfg/targets/help.mk
+++ b/cfg/targets/help.mk
@@ -17,6 +17,8 @@ help:
 	@echo "  DISABLE_QRCODE:         Set to \"1\" to force building without QR export support"
 	@echo "  DISABLE_QRPNG:          Set to \"1\" to force building without QR exported as PNG support"
 	@echo "  ENABLE_PYTHON:          Set to \"1\" to enable building with Python scripting support"
+	@echo "  RELEASE_ENABLED:        Set to \"1\" to build without debug symbols and with full compiler optimizations"
+	@echo "  ASAN_ENABLED:           Set to \"1\" to build with LLVM address sanitizer enabled.
 	@echo "  USER_CFLAGS:            Add custom flags to default CFLAGS"
 	@echo "  USER_LDFLAGS:           Add custom flags to default LDFLAGS"
 	@echo "  PREFIX:                 Specify a prefix directory for binaries, data files,... (default is \"$(abspath $(PREFIX))\")"


### PR DESCRIPTION
The release now uses `-O2` and `flto`, and has no debug symbols. `-Wmissing-field-initializer` was removed due to false positives on newer versions of clang.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxic/143)
<!-- Reviewable:end -->
