### PR TITLE
fix: UI regression 

### DIFF
--- a/src/misc_tools.c
+++ b/src/misc_tools.c
@@ -584,7 +584,11 @@ void set_window_title(ToxWindow *self, const char *title, int len)
 
     char cpy[TOXIC_MAX_NAME_LENGTH + 1];
 
-    snprintf(cpy, sizeof(cpy), "%s", title);
+    if (self->type == WINDOW_TYPE_CONFERENCE) { /* keep conferencenumber in title for invites */
+        snprintf(cpy, sizeof(cpy), "%u %s", self->num, title);
+    } else {
+        snprintf(cpy, sizeof(cpy), "%s", title);
+    }
 
     if (len > MAX_WINDOW_NAME_LENGTH) {
         strcpy(&cpy[MAX_WINDOW_NAME_LENGTH - 3], "...");


### PR DESCRIPTION
The conference number needs to be displayed in the tab name so that you can invite friends to conferences

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxic/146)
<!-- Reviewable:end -->
