### PR TITLE
feat: Add notification counters to bottom tab

### DIFF
--- a/src/global_commands.c
+++ b/src/global_commands.c
@@ -365,7 +365,7 @@ void cmd_conference(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*ar
         return;
     }
 
-    uint32_t conferencenum;
+    uint32_t conferencenum = 0;
 
     if (type == TOX_CONFERENCE_TYPE_TEXT) {
         Tox_Err_Conference_New err;

--- a/src/notify.c
+++ b/src/notify.c
@@ -126,6 +126,8 @@ static void tab_notify(ToxWindow *self, uint64_t flags)
     } else if ((flags & NT_WNDALERT_2) && (!self->alert || self->alert > WINDOW_ALERT_1)) {
         self->alert = WINDOW_ALERT_2;
     }
+
+    ++self->pending_messages;
 }
 
 static bool notifications_are_disabled(uint64_t flags)

--- a/src/windows.c
+++ b/src/windows.c
@@ -502,14 +502,22 @@ static void draw_window_tab(ToxWindow *toxwin, bool active_window)
         attron(COLOR_PAIR(toxwin->alert));
     }
 
+    unsigned int pending_messages = toxwin->pending_messages;
+
     pthread_mutex_unlock(&Winthread.lock);
 
     clrtoeol();
 
-    if (active_window || toxwin->index <= 1) {
+    WINDOW_TYPE type = toxwin->type;
+
+    if (active_window || (type == WINDOW_TYPE_PROMPT || type == WINDOW_TYPE_FRIEND_LIST)) {
         printw(" [%s]", toxwin->name);
     } else {
-        printw(" [%u]", toxwin->index - 1);
+        if (pending_messages > 0) {
+            printw(" [%u]", pending_messages);
+        } else {
+            printw(" [*]");
+        }
     }
 
     pthread_mutex_lock(&Winthread.lock);
@@ -673,6 +681,7 @@ void draw_active_window(Tox *m)
 
     pthread_mutex_lock(&Winthread.lock);
     a->alert = WINDOW_ALERT_NONE;
+    a->pending_messages = 0;
     pthread_mutex_unlock(&Winthread.lock);
 
     draw_bar();

--- a/src/windows.h
+++ b/src/windows.h
@@ -167,6 +167,7 @@ struct ToxWindow {
     char name[TOXIC_MAX_NAME_LENGTH + 1];
     uint32_t num;    /* corresponds to friendnumber in chat windows */
     uint8_t index; /* This window's index in the windows array */
+    unsigned int pending_messages;  /* # of new messages in this window since the last time it was focused */
     int x;
 
     WINDOW_TYPE type;


### PR DESCRIPTION
A counter now increments in the bottom bar for unfocused windows showing how many unread messages are pending. Tabs with no pending messages show `[*]` instead of their index (showing the index is useless and somewhat confusing, as they can go out of order and can be mixed up with conference numbers)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxic/150)
<!-- Reviewable:end -->
