### PR TITLE
fix: some off by one bugs with line scrolling and some cleanup

### DIFF
--- a/src/line_info.h
+++ b/src/line_info.h
@@ -29,7 +29,7 @@
 #define MAX_HISTORY 100000
 #define MIN_HISTORY 40
 #define MAX_LINE_INFO_QUEUE 1024
-#define MAX_LINE_INFO_MSG_SIZE MAX_STR_SIZE + TOXIC_MAX_NAME_LENGTH + 32    /* needs extra room for log loading */
+#define MAX_LINE_INFO_MSG_SIZE (MAX_STR_SIZE + TOXIC_MAX_NAME_LENGTH + 32) /* needs extra room for log loading */
 
 typedef enum {
     SYS_MSG,
@@ -57,9 +57,9 @@ struct line_info {
     uint8_t noread_flag;   /* true if a line should be flagged as unread */
     uint32_t id;
     uint16_t len;        /* combined length of entire line */
-    uint16_t format_len; /* formatted length of combined string (dynamically set by print_wrap()) */
     uint16_t msg_len;    /* length of the message */
     uint8_t newlines;
+    uint16_t format_lines;  /* number of lines the combined string takes up (dynamically set) */
 
     struct line_info *prev;
     struct line_info *next;
@@ -73,7 +73,7 @@ struct history {
     uint32_t start_id;    /* keeps track of where line_start should be when at bottom of history */
 
     struct line_info *queue[MAX_LINE_INFO_QUEUE];
-    int queue_sz;
+    size_t queue_size;
 };
 
 /* creates new line_info line and puts it in the queue.

--- a/src/line_info.h
+++ b/src/line_info.h
@@ -58,7 +58,6 @@ struct line_info {
     uint32_t id;
     uint16_t len;        /* combined length of entire line */
     uint16_t msg_len;    /* length of the message */
-    uint8_t newlines;
     uint16_t format_lines;  /* number of lines the combined string takes up (dynamically set) */
 
     struct line_info *prev;

--- a/src/message_queue.c
+++ b/src/message_queue.c
@@ -88,6 +88,7 @@ static void cqueue_mark_read(ToxWindow *self, struct cqueue_msg *msg)
 
         if (line->noread_flag == true) {
             line->len -= 2;
+            line->msg_len -= 2;
             line->noread_flag = false;
         }
 


### PR DESCRIPTION
Instead of trying (and failing) to correctly calculate the number of lines on the screen a given message will need space for, we dynamically set the value both on initiation of a new line, and whenever that line is printed to the screen using the `print_wrap()` function.

This should fix the screen occasionally not scrolling down the correct number of lines when a new message is printed.

Edit: Also fixed an issue with the line format breaking if a line contained newlines or no spaces

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxic/151)
<!-- Reviewable:end -->
