### PR TITLE
fix: Properly handle failures to convert widechar strings to multibyte

### DIFF
--- a/src/chat.c
+++ b/src/chat.c
@@ -1148,7 +1148,7 @@ bool chat_onKey(ToxWindow *self, Tox *m, wint_t key, bool ltr)
 
             wstrsubst(ctx->line, L'¶', L'\n');
 
-            char line[MAX_STR_SIZE] = {0};
+            char line[MAX_STR_SIZE];
 
             if (wcs_to_mbs_buf(line, ctx->line, MAX_STR_SIZE) == -1) {
                 memset(line, 0, sizeof(line));
@@ -1163,7 +1163,7 @@ bool chat_onKey(ToxWindow *self, Tox *m, wint_t key, bool ltr)
                 } else {
                     execute(ctx->history, self, m, line, CHAT_COMMAND_MODE);
                 }
-            } else {
+            } else if (line[0]) {
                 char selfname[TOX_MAX_NAME_LENGTH];
                 tox_self_get_name(m, (uint8_t *) selfname);
 
@@ -1175,6 +1175,8 @@ bool chat_onKey(ToxWindow *self, Tox *m, wint_t key, bool ltr)
 
                 int id = line_info_add(self, timefrmt, selfname, NULL, OUT_MSG, 0, 0, "%s", line);
                 cqueue_add(ctx->cqueue, line, strlen(line), OUT_MSG, id);
+            } else {
+                line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, RED, " * Failed to parse message.");
             }
         }
 

--- a/src/conference.c
+++ b/src/conference.c
@@ -951,12 +951,14 @@ static bool conference_onKey(ToxWindow *self, Tox *m, wint_t key, bool ltr)
                 } else {
                     execute(ctx->history, self, m, line, CONFERENCE_COMMAND_MODE);
                 }
-            } else {
+            } else if (line[0]) {
                 Tox_Err_Conference_Send_Message err;
 
                 if (!tox_conference_send_message(m, self->num, TOX_MESSAGE_TYPE_NORMAL, (uint8_t *) line, strlen(line), &err)) {
                     line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, RED, " * Failed to send message (error %d)", err);
                 }
+            } else {
+                line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, RED, " * Failed to parse message.");
             }
         }
 

--- a/src/prompt.c
+++ b/src/prompt.c
@@ -281,14 +281,14 @@ static bool prompt_onKey(ToxWindow *self, Tox *m, wint_t key, bool ltr)
             add_line_to_hist(ctx);
             wstrsubst(ctx->line, L'¶', L'\n');
 
-            char line[MAX_STR_SIZE] = {0};
+            char line[MAX_STR_SIZE];
 
             if (wcs_to_mbs_buf(line, ctx->line, MAX_STR_SIZE) == -1) {
-                memset(line, 0, sizeof(line));
+                line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, RED, " * Failed to parse message.");
+            } else {
+                line_info_add(self, NULL, NULL, NULL, PROMPT, 0, 0, "%s", line);
+                execute(ctx->history, self, m, line, GLOBAL_COMMAND_MODE);
             }
-
-            line_info_add(self, NULL, NULL, NULL, PROMPT, 0, 0, "%s", line);
-            execute(ctx->history, self, m, line, GLOBAL_COMMAND_MODE);
         }
 
         wclear(ctx->linewin);


### PR DESCRIPTION
When a string fails to convert from widechar to multibyte we print an error message and clear the buffer instead of trying to send or execute an empty line (which leads to cascading bugs).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxic/153)
<!-- Reviewable:end -->
