### PR TITLE
fix: Another logging fix

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -358,19 +358,8 @@ int rename_logfile(const char *src, const char *dest, const char *selfkey, const
     }
 
     if (file_exists(newpath)) {
-        char new_backup[MAX_STR_SIZE + 4];
-        snprintf(new_backup, sizeof(new_backup), "%s.old", newpath);
-
-        if (file_exists(new_backup)) {
-            goto on_error;
-        }
-
-        if (rename(newpath, new_backup) != 0) {
-            goto on_error;
-        }
-    }
-
-    if (rename(oldpath, newpath) != 0) {
+        remove(oldpath);
+    } else if (rename(oldpath, newpath) != 0) {
         goto on_error;
     }
 


### PR DESCRIPTION
When renaming a log file, if the new name already exists we just start appending to it and delete the old file. There's no need to create a backup.

This fixes an issue where leaving and rejoining the same group multiple times will eventually lead to the logger not working due to trying to use the same file name over and over again. (when you join a new group the initial file name is set to a default name until you connect to the group).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxic/154)
<!-- Reviewable:end -->
