### PR TITLE
fix: tab complete bug

### DIFF
--- a/src/autocomplete.c
+++ b/src/autocomplete.c
@@ -147,7 +147,7 @@ static int complete_line_helper(ToxWindow *self, const char **list, const size_t
         }
     }
 
-    if (!sub[0]) {
+    if (!sub[0] && !(dir_search && n_items == 1)) {
         free(sub);
         return 0;
     }


### PR DESCRIPTION
If a directory contains a single entry tab complete will no longer fail

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxic/157)
<!-- Reviewable:end -->
