### PR TITLE
cleanup: Remove lots of duplicate code related to printing timestamps

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -99,18 +99,16 @@ void api_send(const char *msg)
     }
 
     char *name = api_get_nick();
-    char  timefrmt[TIME_STR_SIZE];
 
     if (name == NULL) {
         return;
     }
 
     self_window = get_active_window();
-    get_time_str(timefrmt, sizeof(timefrmt));
 
     strncpy((char *) self_window->chatwin->line, msg, sizeof(self_window->chatwin->line));
     add_line_to_hist(self_window->chatwin);
-    int id = line_info_add(self_window, timefrmt, name, NULL, OUT_MSG, 0, 0, "%s", msg);
+    int id = line_info_add(self_window, true, name, NULL, OUT_MSG, 0, 0, "%s", msg);
     cqueue_add(self_window->chatwin->cqueue, msg, strlen(msg), OUT_MSG, id);
     free(name);
 }
@@ -156,7 +154,7 @@ void cmd_run(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[MAX
             error_str = "Only one argument allowed.";
         }
 
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, error_str);
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, error_str);
         return;
     }
 
@@ -165,7 +163,7 @@ void cmd_run(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[MAX
     if (fp == NULL) {
         error_str = "Path does not exist.";
 
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, error_str);
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, error_str);
         return;
     }
 

--- a/src/audio_call.c
+++ b/src/audio_call.c
@@ -90,7 +90,7 @@ void audio_bit_rate_callback(ToxAV *av, uint32_t friend_number, uint32_t audio_b
 
 static void print_err(ToxWindow *self, const char *error_str)
 {
-    line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "%s", error_str);
+    line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "%s", error_str);
 }
 
 ToxAV *init_audio(ToxWindow *self, Tox *tox)
@@ -113,13 +113,13 @@ ToxAV *init_audio(ToxWindow *self, Tox *tox)
 
     if (!CallControl.av) {
         CallControl.audio_errors |= ae_StartingCoreAudio;
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Failed to init ToxAV");
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Failed to init ToxAV");
 
         return NULL;
     }
 
     if (init_devices() == de_InternalError) {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Failed to init devices");
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Failed to init devices");
         toxav_kill(CallControl.av);
 
         return CallControl.av = NULL;
@@ -200,7 +200,7 @@ static bool cancel_call(Call *call)
 static int start_transmission(ToxWindow *self, Call *call)
 {
     if (!self || !CallControl.av) {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Failed to prepare audio transmission");
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Failed to prepare audio transmission");
         return -1;
     }
 
@@ -209,17 +209,17 @@ static int start_transmission(ToxWindow *self, Call *call)
 
     if (error != de_None) {
         if (error == de_FailedStart) {
-            line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Failed to start audio input device");
+            line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Failed to start audio input device");
         }
 
         if (error == de_InternalError) {
-            line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Internal error with opening audio input device");
+            line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Internal error with opening audio input device");
         }
     }
 
     if (open_output_device(&call->out_idx,
                            CallControl.audio_sample_rate, CallControl.audio_frame_duration, CallControl.audio_channels) != de_None) {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Failed to open audio output device!");
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Failed to open audio output device!");
     }
 
     return 0;
@@ -342,7 +342,7 @@ void on_call_state(ToxAV *av, uint32_t friend_number, uint32_t state, void *user
         case TOXAV_FRIEND_CALL_STATE_ERROR:
         case TOXAV_FRIEND_CALL_STATE_FINISHED:
             if (state == TOXAV_FRIEND_CALL_STATE_ERROR) {
-                line_info_add(CallControl.prompt, NULL, NULL, NULL, SYS_MSG, 0, 0, "ToxAV callstate error!");
+                line_info_add(CallControl.prompt, false, NULL, NULL, SYS_MSG, 0, 0, "ToxAV callstate error!");
             }
 
             if (call->status == cs_Pending) {
@@ -669,7 +669,7 @@ void cmd_list_devices(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*
     }
 
     else {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Invalid type: %s", argv[1]);
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Invalid type: %s", argv[1]);
         return;
     }
 
@@ -708,7 +708,7 @@ void cmd_change_device(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (
     }
 
     else {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Invalid type: %s", argv[1]);
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Invalid type: %s", argv[1]);
         return;
     }
 
@@ -748,7 +748,7 @@ void cmd_mute(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[MA
     }
 
     else {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Invalid type: %s", argv[1]);
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Invalid type: %s", argv[1]);
         return;
     }
 
@@ -816,7 +816,7 @@ void cmd_bitrate(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)
     }
 
     if (argc == 0) {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0,
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0,
                       "Current audio encoding bitrate: %u", call->audio_bit_rate);
         return;
     }

--- a/src/audio_device.c
+++ b/src/audio_device.c
@@ -775,7 +775,7 @@ float get_input_volume(void)
 void print_al_devices(ToxWindow *self, DeviceType type)
 {
     for (int i = 0; i < audio_state->num_al_devices[type]; ++i) {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG,
+        line_info_add(self, false, NULL, NULL, SYS_MSG,
                       audio_state->current_al_device_name[type]
                       && strcmp(audio_state->current_al_device_name[type], audio_state->al_device_names[type][i]) == 0 ? 1 : 0,
                       0, "%d: %s", i, audio_state->al_device_names[type][i]);

--- a/src/autocomplete.c
+++ b/src/autocomplete.c
@@ -45,10 +45,10 @@ static void print_ac_matches(ToxWindow *self, Tox *m, char **list, size_t n_matc
     }
 
     for (size_t i = 0; i < n_matches; ++i) {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "%s", list[i]);
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "%s", list[i]);
     }
 
-    line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "");
+    line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "");
 }
 
 /* puts match in match buffer. if more than one match, add first n chars that are identical.

--- a/src/chat_commands.c
+++ b/src/chat_commands.c
@@ -41,7 +41,7 @@ void cmd_cancelfile(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*ar
     UNUSED_VAR(window);
 
     if (argc < 2) {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Requires type in|out and the file ID.");
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Requires type in|out and the file ID.");
         return;
     }
 
@@ -50,7 +50,7 @@ void cmd_cancelfile(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*ar
     long int idx = strtol(argv[2], NULL, 10);
 
     if ((idx == 0 && strcmp(argv[2], "0")) || idx >= MAX_FILES || idx < 0) {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Invalid file ID.");
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Invalid file ID.");
         return;
     }
 
@@ -62,17 +62,17 @@ void cmd_cancelfile(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*ar
     } else if (strcasecmp(inoutstr, "out") == 0) {
         ft = get_file_transfer_struct_index(self->num, idx, FILE_TRANSFER_SEND);
     } else {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Type must be 'in' or 'out'.");
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Type must be 'in' or 'out'.");
         return;
     }
 
     if (!ft) {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Invalid file ID.");
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Invalid file ID.");
         return;
     }
 
     if (ft->state == FILE_TRANSFER_INACTIVE) {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Invalid file ID.");
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Invalid file ID.");
         return;
     }
 
@@ -85,25 +85,25 @@ void cmd_conference_invite(WINDOW *window, ToxWindow *self, Tox *m, int argc, ch
     UNUSED_VAR(window);
 
     if (argc < 1) {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Conference number required.");
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Conference number required.");
         return;
     }
 
     long int conferencenum = strtol(argv[1], NULL, 10);
 
     if ((conferencenum == 0 && strcmp(argv[1], "0")) || conferencenum < 0 || conferencenum == LONG_MAX) {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Invalid conference number.");
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Invalid conference number.");
         return;
     }
 
     Tox_Err_Conference_Invite err;
 
     if (!tox_conference_invite(m, self->num, conferencenum, &err)) {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Failed to invite contact to conference (error %d)", err);
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Failed to invite contact to conference (error %d)", err);
         return;
     }
 
-    line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Invited contact to Conference %ld.", conferencenum);
+    line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Invited contact to Conference %ld.", conferencenum);
 }
 
 void cmd_conference_join(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[MAX_STR_SIZE])
@@ -113,7 +113,7 @@ void cmd_conference_join(WINDOW *window, ToxWindow *self, Tox *m, int argc, char
     UNUSED_VAR(argv);
 
     if (get_num_active_windows() >= MAX_WINDOWS_NUM) {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, RED, " * Warning: Too many windows are open.");
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, RED, " * Warning: Too many windows are open.");
         return;
     }
 
@@ -122,7 +122,7 @@ void cmd_conference_join(WINDOW *window, ToxWindow *self, Tox *m, int argc, char
     uint8_t type = Friends.list[self->num].conference_invite.type;
 
     if (!Friends.list[self->num].conference_invite.pending) {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "No pending conference invite.");
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "No pending conference invite.");
         return;
     }
 
@@ -133,7 +133,7 @@ void cmd_conference_join(WINDOW *window, ToxWindow *self, Tox *m, int argc, char
         conferencenum = tox_conference_join(m, self->num, (const uint8_t *) conferencekey, length, &err);
 
         if (err != TOX_ERR_CONFERENCE_JOIN_OK) {
-            line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Conference instance failed to initialize (error %d)", err);
+            line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Conference instance failed to initialize (error %d)", err);
             return;
         }
     } else if (type == TOX_CONFERENCE_TYPE_AV) {
@@ -142,21 +142,21 @@ void cmd_conference_join(WINDOW *window, ToxWindow *self, Tox *m, int argc, char
                                                 audio_conference_callback, NULL);
 
         if (conferencenum == (uint32_t) -1) {
-            line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Audio conference instance failed to initialize");
+            line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Audio conference instance failed to initialize");
             return;
         }
 
 #else
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Audio support disabled by compile-time option.");
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Audio support disabled by compile-time option.");
         return;
 #endif
     } else {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Unknown conference type %d", type);
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Unknown conference type %d", type);
         return;
     }
 
     if (init_conference_win(m, conferencenum, type, NULL, 0) == -1) {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Conference window failed to initialize.");
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Conference window failed to initialize.");
         tox_conference_delete(m, conferencenum, NULL);
         return;
     }
@@ -165,7 +165,7 @@ void cmd_conference_join(WINDOW *window, ToxWindow *self, Tox *m, int argc, char
 
     if (type == TOX_CONFERENCE_TYPE_AV) {
         if (!init_conference_audio_input(m, conferencenum)) {
-            line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Audio capture failed; use \"/audio on\" to try again.");
+            line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Audio capture failed; use \"/audio on\" to try again.");
         }
     }
 
@@ -177,26 +177,26 @@ void cmd_savefile(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv
     UNUSED_VAR(window);
 
     if (argc < 1) {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "File ID required.");
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "File ID required.");
         return;
     }
 
     long int idx = strtol(argv[1], NULL, 10);
 
     if ((idx == 0 && strcmp(argv[1], "0")) || idx < 0 || idx >= MAX_FILES) {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "No pending file transfers with that ID.");
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "No pending file transfers with that ID.");
         return;
     }
 
     struct FileTransfer *ft = get_file_transfer_struct_index(self->num, idx, FILE_TRANSFER_RECV);
 
     if (!ft) {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "No pending file transfers with that ID.");
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "No pending file transfers with that ID.");
         return;
     }
 
     if (ft->state != FILE_TRANSFER_PENDING) {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "No pending file transfers with that ID.");
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "No pending file transfers with that ID.");
         return;
     }
 
@@ -213,12 +213,12 @@ void cmd_savefile(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv
         goto on_recv_error;
     }
 
-    line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Saving file [%ld] as: '%s'", idx, ft->file_path);
+    line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Saving file [%ld] as: '%s'", idx, ft->file_path);
 
     /* prep progress bar line */
     char progline[MAX_STR_SIZE];
     init_progress_bar(progline);
-    line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "%s", progline);
+    line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "%s", progline);
 
     ft->line_id = self->chatwin->hst->line_end->id + 2;
     ft->state = FILE_TRANSFER_STARTED;
@@ -229,23 +229,23 @@ on_recv_error:
 
     switch (err) {
         case TOX_ERR_FILE_CONTROL_FRIEND_NOT_FOUND:
-            line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "File transfer failed: Friend not found.");
+            line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "File transfer failed: Friend not found.");
             return;
 
         case TOX_ERR_FILE_CONTROL_FRIEND_NOT_CONNECTED:
-            line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "File transfer failed: Friend is not online.");
+            line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "File transfer failed: Friend is not online.");
             return;
 
         case TOX_ERR_FILE_CONTROL_NOT_FOUND:
-            line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "File transfer failed: Invalid filenumber.");
+            line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "File transfer failed: Invalid filenumber.");
             return;
 
         case TOX_ERR_FILE_CONTROL_SENDQ:
-            line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "File transfer failed: Connection error.");
+            line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "File transfer failed: Connection error.");
             return;
 
         default:
-            line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "File transfer failed (error %d)\n", err);
+            line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "File transfer failed (error %d)\n", err);
             return;
     }
 }
@@ -257,7 +257,7 @@ void cmd_sendfile(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv
     const char *errmsg = NULL;
 
     if (argc < 1) {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "File path required.");
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "File path required.");
         return;
     }
 
@@ -266,21 +266,21 @@ void cmd_sendfile(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv
     int path_len = strlen(path);
 
     if (path_len >= MAX_STR_SIZE) {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "File path exceeds character limit.");
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "File path exceeds character limit.");
         return;
     }
 
     FILE *file_to_send = fopen(path, "r");
 
     if (file_to_send == NULL) {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "File not found.");
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "File not found.");
         return;
     }
 
     off_t filesize = file_size(path);
 
     if (filesize == 0) {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Invalid file.");
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Invalid file.");
         fclose(file_to_send);
         return;
     }
@@ -310,7 +310,7 @@ void cmd_sendfile(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv
 
     char sizestr[32];
     bytes_convert_str(sizestr, sizeof(sizestr), filesize);
-    line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Sending file [%d]: '%s' (%s)", filenum, file_name, sizestr);
+    line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Sending file [%d]: '%s' (%s)", filenum, file_name, sizestr);
 
     return;
 
@@ -338,7 +338,7 @@ on_send_error:
             break;
     }
 
-    line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "%s", errmsg);
+    line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "%s", errmsg);
     tox_file_control(m, self->num, filenum, TOX_FILE_CONTROL_CANCEL, NULL);
     fclose(file_to_send);
 }

--- a/src/conference_commands.c
+++ b/src/conference_commands.c
@@ -32,7 +32,7 @@
 
 static void print_err(ToxWindow *self, const char *error_str)
 {
-    line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "%s", error_str);
+    line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "%s", error_str);
 }
 
 void cmd_conference_set_title(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[MAX_STR_SIZE])
@@ -56,7 +56,7 @@ void cmd_conference_set_title(WINDOW *window, ToxWindow *self, Tox *m, int argc,
         }
 
         title[tlen] = '\0';
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Title is set to: %s", title);
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Title is set to: %s", title);
 
         return;
     }
@@ -64,14 +64,14 @@ void cmd_conference_set_title(WINDOW *window, ToxWindow *self, Tox *m, int argc,
     size_t len = strlen(argv[1]);
 
     if (len >= sizeof(title)) {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Failed to set title: max length exceeded.");
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Failed to set title: max length exceeded.");
         return;
     }
 
     snprintf(title, sizeof(title), "%s", argv[1]);
 
     if (!tox_conference_set_title(m, self->num, (uint8_t *) title, len, &err)) {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Failed to set title (error %d)", err);
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Failed to set title (error %d)", err);
         return;
     }
 
@@ -79,16 +79,13 @@ void cmd_conference_set_title(WINDOW *window, ToxWindow *self, Tox *m, int argc,
 
     conference_set_title(self, self->num, title, len);
 
-    char timefrmt[TIME_STR_SIZE];
     char selfnick[TOX_MAX_NAME_LENGTH];
-
-    get_time_str(timefrmt, sizeof(timefrmt));
-
     tox_self_get_name(m, (uint8_t *) selfnick);
+
     size_t sn_len = tox_self_get_name_size(m);
     selfnick[sn_len] = '\0';
 
-    line_info_add(self, timefrmt, selfnick, NULL, NAME_CHANGE, 0, 0, " set the conference title to: %s", title);
+    line_info_add(self, true, selfnick, NULL, NAME_CHANGE, 0, 0, " set the conference title to: %s", title);
 
     char tmp_event[MAX_STR_SIZE + 20];
     snprintf(tmp_event, sizeof(tmp_event), "set title to %s", title);
@@ -142,14 +139,14 @@ void cmd_conference_mute(WINDOW *window, ToxWindow *self, Tox *m, int argc, char
             print_err(self, "Multiple matching peers (use /mute [public key] to disambiguate):");
 
             for (uint32_t i = 0; i < n; ++i) {
-                line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "%s: %s", entries[i]->pubkey_str, entries[i]->name);
+                line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "%s: %s", entries[i]->pubkey_str, entries[i]->name);
             }
 
             return;
         }
 
         if (conference_mute_peer(m, self->num, entries[0]->peernum)) {
-            line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Toggled audio mute status of %s", entries[0]->name);
+            line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Toggled audio mute status of %s", entries[0]->name);
         } else {
             print_err(self, "Peer is not on the call");
         }
@@ -162,7 +159,7 @@ void cmd_conference_sense(WINDOW *window, ToxWindow *self, Tox *m, int argc, cha
     UNUSED_VAR(m);
 
     if (argc == 0) {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Current VAD threshold: %.1f",
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Current VAD threshold: %.1f",
                       (double) conference_get_VAD_threshold(self->num));
         return;
     }
@@ -181,7 +178,7 @@ void cmd_conference_sense(WINDOW *window, ToxWindow *self, Tox *m, int argc, cha
     }
 
     if (conference_set_VAD_threshold(self->num, value)) {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Set VAD threshold to %.1f", (double) value);
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Set VAD threshold to %.1f", (double) value);
     } else {
         print_err(self, "Failed to set conference audio input sensitivity.");
     }

--- a/src/execute.c
+++ b/src/execute.c
@@ -271,5 +271,5 @@ void execute(WINDOW *w, ToxWindow *self, Tox *m, const char *input, int mode)
 
 #endif
 
-    line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Invalid command.");
+    line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Invalid command.");
 }

--- a/src/file_transfers.c
+++ b/src/file_transfers.c
@@ -274,7 +274,7 @@ void close_file_transfer(ToxWindow *self, Tox *m, struct FileTransfer *ft, int C
             box_notify(self, sound_type, NT_NOFOCUS | NT_WNDALERT_2, &self->active_box, self->name, "%s", message);
         }
 
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "%s", message);
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "%s", message);
     }
 
     clear_file_transfer(ft);

--- a/src/friendlist.c
+++ b/src/friendlist.c
@@ -397,11 +397,8 @@ static void friendlist_onMessage(ToxWindow *self, Tox *m, uint32_t num, Tox_Mess
     char nick[TOX_MAX_NAME_LENGTH];
     get_nick_truncate(m, nick, num);
 
-    char timefrmt[TIME_STR_SIZE];
-    get_time_str(timefrmt, sizeof(timefrmt));
-
-    line_info_add(prompt, timefrmt, nick, NULL, IN_MSG, 0, 0, "%s", str);
-    line_info_add(prompt, NULL, NULL, NULL, SYS_MSG, 0, RED, "* Warning: Too many windows are open.");
+    line_info_add(prompt, true, nick, NULL, IN_MSG, 0, 0, "%s", str);
+    line_info_add(prompt, false, NULL, NULL, SYS_MSG, 0, RED, "* Warning: Too many windows are open.");
     sound_notify(prompt, notif_error, NT_WNDALERT_1, NULL);
 }
 
@@ -611,7 +608,7 @@ static void friendlist_onFileRecv(ToxWindow *self, Tox *m, uint32_t num, uint32_
     char nick[TOX_MAX_NAME_LENGTH];
     get_nick_truncate(m, nick, num);
 
-    line_info_add(prompt, NULL, NULL, NULL, SYS_MSG, 0, RED,
+    line_info_add(prompt, false, NULL, NULL, SYS_MSG, 0, RED,
                   "* File transfer from %s failed: too many windows are open.", nick);
 
     sound_notify(prompt, notif_error, NT_WNDALERT_1, NULL);
@@ -642,7 +639,7 @@ static void friendlist_onConferenceInvite(ToxWindow *self, Tox *m, int32_t num, 
     char nick[TOX_MAX_NAME_LENGTH];
     get_nick_truncate(m, nick, num);
 
-    line_info_add(prompt, NULL, NULL, NULL, SYS_MSG, 0, RED,
+    line_info_add(prompt, false, NULL, NULL, SYS_MSG, 0, RED,
                   "* Conference chat invite from %s failed: too many windows are open.", nick);
 
     sound_notify(prompt, notif_error, NT_WNDALERT_1, NULL);
@@ -854,7 +851,7 @@ static void unblock_friend(Tox *m, uint32_t bnum)
     uint32_t friendnum = tox_friend_add_norequest(m, (uint8_t *) Blocked.list[bnum].pub_key, &err);
 
     if (err != TOX_ERR_FRIEND_ADD_OK) {
-        line_info_add(prompt, NULL, NULL, NULL, SYS_MSG, 0, 0, "Failed to unblock friend (error %d)", err);
+        line_info_add(prompt, false, NULL, NULL, SYS_MSG, 0, 0, "Failed to unblock friend (error %d)", err);
         return;
     }
 
@@ -923,7 +920,7 @@ static bool friendlist_onKey(ToxWindow *self, Tox *m, wint_t key, bool ltr)
                 set_active_window_index(Friends.list[f].chatwin);
             } else {
                 const char *msg = "* Warning: Too many windows are open.";
-                line_info_add(prompt, NULL, NULL, NULL, SYS_MSG, 0, RED, msg);
+                line_info_add(prompt, false, NULL, NULL, SYS_MSG, 0, RED, msg);
                 sound_notify(prompt, notif_error, NT_WNDALERT_1, NULL);
             }
 
@@ -1307,10 +1304,10 @@ static void friendlist_onAV(ToxWindow *self, ToxAV *av, uint32_t friend_number, 
         } else {
             char nick[TOX_MAX_NAME_LENGTH];
             get_nick_truncate(m, nick, Friends.list[friend_number].num);
-            line_info_add(prompt, NULL, NULL, NULL, SYS_MSG, 0, 0, "Audio action from: %s!", nick);
+            line_info_add(prompt, false, NULL, NULL, SYS_MSG, 0, 0, "Audio action from: %s!", nick);
 
             const char *errmsg = "* Warning: Too many windows are open.";
-            line_info_add(prompt, NULL, NULL, NULL, SYS_MSG, 0, RED, errmsg);
+            line_info_add(prompt, false, NULL, NULL, SYS_MSG, 0, RED, errmsg);
 
             sound_notify(prompt, notif_error, NT_WNDALERT_1, NULL);
         }

--- a/src/global_commands.c
+++ b/src/global_commands.c
@@ -49,19 +49,19 @@ void cmd_accept(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[
     UNUSED_VAR(window);
 
     if (argc < 1) {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Request ID required.");
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Request ID required.");
         return;
     }
 
     long int req = strtol(argv[1], NULL, 10);
 
     if ((req == 0 && strcmp(argv[1], "0")) || req < 0 || req >= MAX_FRIEND_REQUESTS) {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "No pending friend request with that ID.");
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "No pending friend request with that ID.");
         return;
     }
 
     if (!FrndRequests.request[req].active) {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "No pending friend request with that ID.");
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "No pending friend request with that ID.");
         return;
     }
 
@@ -69,10 +69,10 @@ void cmd_accept(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[
     uint32_t friendnum = tox_friend_add_norequest(m, FrndRequests.request[req].key, &err);
 
     if (err != TOX_ERR_FRIEND_ADD_OK) {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Failed to add friend (error %d\n)", err);
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Failed to add friend (error %d\n)", err);
         return;
     } else {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Friend request accepted.");
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Friend request accepted.");
         on_friend_added(m, friendnum, true);
     }
 
@@ -141,7 +141,7 @@ void cmd_add_helper(ToxWindow *self, Tox *m, const char *id_bin, const char *msg
             break;
     }
 
-    line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, errmsg);
+    line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, errmsg);
 }
 
 void cmd_add(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[MAX_STR_SIZE])
@@ -149,7 +149,7 @@ void cmd_add(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[MAX
     UNUSED_VAR(window);
 
     if (argc < 1) {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Tox ID or address required.");
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Tox ID or address required.");
         return;
     }
 
@@ -158,7 +158,7 @@ void cmd_add(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[MAX
 
     if (argc > 1) {
         if (argv[2][0] != '\"') {
-            line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Message must be enclosed in quotes.");
+            line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Message must be enclosed in quotes.");
             return;
         }
 
@@ -192,7 +192,7 @@ void cmd_add(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[MAX
             xx[2] = '\0';
 
             if (sscanf(xx, "%02x", &x) != 1) {
-                line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Invalid Tox ID.");
+                line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Invalid Tox ID.");
                 return;
             }
 
@@ -200,7 +200,7 @@ void cmd_add(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[MAX
         }
 
         if (friend_is_blocked(id_bin)) {
-            line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Friend is in your block list.");
+            line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Friend is in your block list.");
             return;
         }
 
@@ -216,7 +216,7 @@ void cmd_avatar(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[
 
     if (argc != 1 || strlen(argv[1]) < 3) {
         avatar_unset(m);
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Avatar has been unset.");
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Avatar has been unset.");
         return;
     }
 
@@ -225,7 +225,7 @@ void cmd_avatar(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[
     int len = strlen(path);
 
     if (len <= 0) {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Invalid path.");
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Invalid path.");
         return;
     }
 
@@ -234,13 +234,13 @@ void cmd_avatar(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[
     get_file_name(filename, sizeof(filename), path);
 
     if (avatar_set(m, path, len) == -1) {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0,
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0,
                       "Failed to set avatar. Avatars must be in PNG format and may not exceed %d bytes.",
                       MAX_AVATAR_FILE_SIZE);
         return;
     }
 
-    line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Avatar set to '%s'", filename);
+    line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Avatar set to '%s'", filename);
 }
 
 void cmd_clear(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[MAX_STR_SIZE])
@@ -258,7 +258,7 @@ void cmd_connect(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)
     UNUSED_VAR(window);
 
     if (argc != 3) {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Require: <ip> <port> <key>");
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Require: <ip> <port> <key>");
         return;
     }
 
@@ -269,14 +269,14 @@ void cmd_connect(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)
     long int port = strtol(port_str, NULL, 10);
 
     if (port <= 0 || port > MAX_PORT_RANGE) {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Invalid port.");
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Invalid port.");
         return;
     }
 
     char key_binary[TOX_PUBLIC_KEY_SIZE * 2 + 1];
 
     if (hex_string_to_bin(ascii_key, strlen(ascii_key), key_binary, TOX_PUBLIC_KEY_SIZE) == -1) {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Invalid key.");
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Invalid key.");
         return;
     }
 
@@ -286,15 +286,15 @@ void cmd_connect(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)
 
     switch (err) {
         case TOX_ERR_BOOTSTRAP_BAD_HOST:
-            line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Bootstrap failed: Invalid IP.");
+            line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Bootstrap failed: Invalid IP.");
             break;
 
         case TOX_ERR_BOOTSTRAP_BAD_PORT:
-            line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Bootstrap failed: Invalid port.");
+            line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Bootstrap failed: Invalid port.");
             break;
 
         case TOX_ERR_BOOTSTRAP_NULL:
-            line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Bootstrap failed.");
+            line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Bootstrap failed.");
             break;
 
         default:
@@ -308,19 +308,19 @@ void cmd_decline(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)
     UNUSED_VAR(m);
 
     if (argc < 1) {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Request ID required.");
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Request ID required.");
         return;
     }
 
     long int req = strtol(argv[1], NULL, 10);
 
     if ((req == 0 && strcmp(argv[1], "0")) || req < 0 || req >= MAX_FRIEND_REQUESTS) {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "No pending friend request with that ID.");
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "No pending friend request with that ID.");
         return;
     }
 
     if (!FrndRequests.request[req].active) {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "No pending friend request with that ID.");
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "No pending friend request with that ID.");
         return;
     }
 
@@ -345,12 +345,12 @@ void cmd_conference(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*ar
     UNUSED_VAR(window);
 
     if (get_num_active_windows() >= MAX_WINDOWS_NUM) {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, RED, " * Warning: Too many windows are open.");
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, RED, " * Warning: Too many windows are open.");
         return;
     }
 
     if (argc < 1) {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Please specify conference type: text | audio");
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Please specify conference type: text | audio");
         return;
     }
 
@@ -361,7 +361,7 @@ void cmd_conference(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*ar
     } else if (!strcasecmp(argv[1], "text")) {
         type = TOX_CONFERENCE_TYPE_TEXT;
     } else {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Valid conference types are: text | audio");
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Valid conference types are: text | audio");
         return;
     }
 
@@ -373,7 +373,7 @@ void cmd_conference(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*ar
         conferencenum = tox_conference_new(m, &err);
 
         if (err != TOX_ERR_CONFERENCE_NEW_OK) {
-            line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Conference instance failed to initialize (error %d)", err);
+            line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Conference instance failed to initialize (error %d)", err);
             return;
         }
     } else if (type == TOX_CONFERENCE_TYPE_AV) {
@@ -381,18 +381,18 @@ void cmd_conference(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*ar
         conferencenum = toxav_add_av_groupchat(m, audio_conference_callback, NULL);
 
         if (conferencenum == (uint32_t) -1) {
-            line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Audio conference instance failed to initialize");
+            line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Audio conference instance failed to initialize");
             return;
         }
 
 #else
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Audio support disabled by compile-time option.");
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Audio support disabled by compile-time option.");
         return;
 #endif
     }
 
     if (init_conference_win(m, conferencenum, type, NULL, 0) == -1) {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Conference window failed to initialize.");
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Conference window failed to initialize.");
         tox_conference_delete(m, conferencenum, NULL);
         return;
     }
@@ -401,13 +401,13 @@ void cmd_conference(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*ar
 
     if (type == TOX_CONFERENCE_TYPE_AV) {
         if (!init_conference_audio_input(m, conferencenum)) {
-            line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Audio capture failed; use \"/audio on\" to try again.");
+            line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Audio capture failed; use \"/audio on\" to try again.");
         }
     }
 
 #endif
 
-    line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Conference [%d] created.", conferencenum);
+    line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Conference [%d] created.", conferencenum);
 }
 
 void cmd_log(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[MAX_STR_SIZE])
@@ -424,7 +424,7 @@ void cmd_log(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[MAX
             msg = "Logging for this window is OFF; type \"/log on\" to enable.";
         }
 
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, msg);
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, msg);
         return;
     }
 
@@ -432,7 +432,7 @@ void cmd_log(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[MAX
 
     if (!strcmp(swch, "1") || !strcmp(swch, "on")) {
         msg = log_enable(log) == 0 ? "Logging enabled." : "Warning: Failed to enable log.";
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, msg);
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, msg);
         return;
     } else if (!strcmp(swch, "0") || !strcmp(swch, "off")) {
         if (self->type == WINDOW_TYPE_CHAT) {
@@ -442,12 +442,12 @@ void cmd_log(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[MAX
         log_disable(log);
 
         msg = "Logging disabled.";
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, msg);
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, msg);
         return;
     }
 
     msg = "Invalid option. Use \"/log on\" and \"/log off\" to toggle logging.";
-    line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, msg);
+    line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, msg);
 }
 
 void cmd_myid(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[MAX_STR_SIZE])
@@ -461,11 +461,11 @@ void cmd_myid(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[MA
     tox_self_get_address(m, (uint8_t *) bin_id);
 
     if (bin_id_to_string(bin_id, sizeof(bin_id), id_string, sizeof(id_string)) == -1) {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Failed to print ID.");
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Failed to print ID.");
         return;
     }
 
-    line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "%s", id_string);
+    line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "%s", id_string);
 }
 
 #ifdef QRCODE
@@ -478,7 +478,7 @@ void cmd_myqr(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[MA
     tox_self_get_address(m, (uint8_t *) bin_id);
 
     if (bin_id_to_string(bin_id, sizeof(bin_id), id_string, sizeof(id_string)) == -1) {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Failed to create QR code.");
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Failed to create QR code.");
         return;
     }
 
@@ -491,7 +491,7 @@ void cmd_myqr(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[MA
     char *dir = malloc(data_file_len + 1);
 
     if (dir == NULL) {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Failed to create QR code: Out of memory.");
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Failed to create QR code: Out of memory.");
         return;
     }
 
@@ -500,7 +500,7 @@ void cmd_myqr(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[MA
 #ifdef QRPNG
 
     if (argc == 0) {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Required 'txt' or 'png'");
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Required 'txt' or 'png'");
         free(dir);
         return;
     } else if (!strcmp(argv[1], "txt")) {
@@ -510,7 +510,7 @@ void cmd_myqr(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[MA
         char *qr_path = malloc(qr_path_buf_size);
 
         if (qr_path == NULL) {
-            line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Failed to create QR code: Out of memory");
+            line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Failed to create QR code: Out of memory");
             free(dir);
             return;
         }
@@ -518,13 +518,13 @@ void cmd_myqr(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[MA
         snprintf(qr_path, qr_path_buf_size, "%s%s%s", dir, nick, QRCODE_FILENAME_EXT);
 
         if (ID_to_QRcode_txt(id_string, qr_path) == -1) {
-            line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Failed to create QR code.");
+            line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Failed to create QR code.");
             free(dir);
             free(qr_path);
             return;
         }
 
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "QR code has been printed to the file '%s'", qr_path);
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "QR code has been printed to the file '%s'", qr_path);
 
         free(qr_path);
 
@@ -534,7 +534,7 @@ void cmd_myqr(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[MA
         char *qr_path = malloc(qr_path_buf_size);
 
         if (qr_path == NULL) {
-            line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Failed to create QR code: Out of memory");
+            line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Failed to create QR code: Out of memory");
             free(dir);
             return;
         }
@@ -542,18 +542,18 @@ void cmd_myqr(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[MA
         snprintf(qr_path, qr_path_buf_size, "%s%s%s", dir, nick, QRCODE_FILENAME_EXT_PNG);
 
         if (ID_to_QRcode_png(id_string, qr_path) == -1) {
-            line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Failed to create QR code.");
+            line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Failed to create QR code.");
             free(dir);
             free(qr_path);
             return;
         }
 
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "QR code has been printed to the file '%s'", qr_path);
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "QR code has been printed to the file '%s'", qr_path);
 
         free(qr_path);
 
     } else {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Unknown option '%s' -- Required 'txt' or 'png'", argv[1]);
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Unknown option '%s' -- Required 'txt' or 'png'", argv[1]);
         free(dir);
         return;
     }
@@ -569,7 +569,7 @@ void cmd_nick(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[MA
     UNUSED_VAR(window);
 
     if (argc < 1) {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Input required.");
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Input required.");
         return;
     }
 
@@ -578,7 +578,7 @@ void cmd_nick(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[MA
     size_t len = strlen(nick);
 
     if (!valid_nick(nick)) {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Invalid name.");
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Invalid name.");
         return;
     }
 
@@ -596,7 +596,7 @@ void cmd_note(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[MA
     UNUSED_VAR(window);
 
     if (argc < 1) {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Input required.");
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Input required.");
         return;
     }
 
@@ -611,7 +611,7 @@ void cmd_nospam(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[
         nospam = strtol(argv[1], NULL, 16);
 
         if ((nospam == 0 && strcmp(argv[1], "0")) || nospam < 0) {
-            line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Invalid nospam value.");
+            line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Invalid nospam value.");
             return;
         }
     }
@@ -619,12 +619,12 @@ void cmd_nospam(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[
     uint32_t old_nospam = tox_self_get_nospam(m);
     tox_self_set_nospam(m, (uint32_t) nospam);
 
-    line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Your new Tox ID is:");
+    line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Your new Tox ID is:");
     cmd_myid(window, self, m, 0, NULL);
-    line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "");
-    line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0,
+    line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "");
+    line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0,
                   "Any services that relied on your old ID will need to be updated manually.");
-    line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "If you ever want your old Tox ID back, type '/nospam %X'",
+    line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "If you ever want your old Tox ID back, type '/nospam %X'",
                   old_nospam);
 }
 
@@ -656,7 +656,7 @@ void cmd_requests(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv
     UNUSED_VAR(argv);
 
     if (FrndRequests.num_requests == 0) {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "No pending friend requests.");
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "No pending friend requests.");
         return;
     }
 
@@ -676,11 +676,11 @@ void cmd_requests(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv
             strcat(id, d);
         }
 
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "%d : %s", i, id);
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "%s", FrndRequests.request[i].msg);
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "%d : %s", i, id);
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "%s", FrndRequests.request[i].msg);
 
         if (++count < FrndRequests.num_requests) {
-            line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "");
+            line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "");
         }
     }
 }
@@ -695,7 +695,7 @@ void cmd_status(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[
 
     if (argc < 1) {
         errmsg = "Require a status. Statuses are: online, busy and away.";
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, errmsg);
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, errmsg);
         goto finish;
     }
 
@@ -710,13 +710,13 @@ void cmd_status(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[
         status = TOX_USER_STATUS_BUSY;
     } else {
         errmsg = "Invalid status. Valid statuses are: online, busy and away.";
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, errmsg);
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, errmsg);
         goto finish;
     }
 
     tox_self_set_status(m, status);
     prompt_update_status(prompt, status);
-    line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Your status has been changed to %s.", status_str);
+    line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Your status has been changed to %s.", status_str);
 
 
 finish:

--- a/src/line_info.c
+++ b/src/line_info.c
@@ -339,7 +339,7 @@ static void line_info_init_line(ToxWindow *self, struct line_info *line)
  * Returns the id of the new line.
  * Returns -1 on failure.
  */
-int line_info_add(ToxWindow *self, const char *timestr, const char *name1, const char *name2, uint8_t type,
+int line_info_add(ToxWindow *self, bool show_timestamp, const char *name1, const char *name2, LINE_TYPE type,
                   uint8_t bold, uint8_t colour, const char *msg, ...)
 {
     if (!self) {
@@ -416,8 +416,8 @@ int line_info_add(ToxWindow *self, const char *timestr, const char *name1, const
         len += msg_len;
     }
 
-    if (timestr) {
-        snprintf(new_line->timestr, sizeof(new_line->timestr), "%s", timestr);
+    if (show_timestamp) {
+        get_time_str(new_line->timestr, sizeof(new_line->timestr));
         len += strlen(new_line->timestr) + 1;
     }
 

--- a/src/line_info.h
+++ b/src/line_info.h
@@ -31,7 +31,7 @@
 #define MAX_LINE_INFO_QUEUE 1024
 #define MAX_LINE_INFO_MSG_SIZE (MAX_STR_SIZE + TOXIC_MAX_NAME_LENGTH + 32) /* needs extra room for log loading */
 
-typedef enum {
+typedef enum LINE_TYPE {
     SYS_MSG,
     IN_MSG,
     OUT_MSG,
@@ -81,7 +81,7 @@ struct history {
  * Returns the id of the new line.
  * Returns -1 on failure.
  */
-int line_info_add(ToxWindow *self, const char *timestr, const char *name1, const char *name2, uint8_t type,
+int line_info_add(ToxWindow *self, bool show_timestamp, const char *name1, const char *name2, LINE_TYPE type,
                   uint8_t bold, uint8_t colour, const char *msg, ...);
 
 /* Prints a section of history starting at line_start */

--- a/src/log.c
+++ b/src/log.c
@@ -302,11 +302,11 @@ int load_chat_history(ToxWindow *self, struct chatlog *log)
     }
 
     while (line != NULL && count--) {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "%s", line);
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "%s", line);
         line = strtok_r(NULL, "\n", &tmp);
     }
 
-    line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, YELLOW, "---");
+    line_info_add(self, false, NULL, NULL, SYS_MSG, 0, YELLOW, "---");
 
     free(buf);
 

--- a/src/misc_tools.c
+++ b/src/misc_tools.c
@@ -96,11 +96,16 @@ struct tm *get_time(void)
     return timeinfo;
 }
 
-/*Puts the current time in buf in the format of [HH:mm:ss] */
-void get_time_str(char *buf, int bufsize)
+/* Puts the current time in buf in the format of specified by the config */
+void get_time_str(char *buf, size_t bufsize)
 {
+    if (buf == NULL || bufsize == 0) {
+        return;
+    }
+
+    *buf = 0;
+
     if (user_settings->timestamps == TIMESTAMPS_OFF) {
-        buf[0] = '\0';
         return;
     }
 

--- a/src/misc_tools.h
+++ b/src/misc_tools.h
@@ -81,8 +81,8 @@ int bin_pubkey_to_string(const uint8_t *bin_pubkey, size_t bin_pubkey_size, char
 /* get the current unix time (not thread safe) */
 time_t get_unix_time(void);
 
-/* Puts the current time in buf in the format of [HH:mm:ss] (not thread safe) */
-void get_time_str(char *buf, int bufsize);
+/* Puts the current time in buf in the format of specified by the config */
+void get_time_str(char *buf, size_t bufsize);
 
 /* Converts seconds to string in format HH:mm:ss; truncates hours and minutes when necessary */
 void get_elapsed_time_str(char *buf, int bufsize, time_t secs);

--- a/src/name_lookup.c
+++ b/src/name_lookup.c
@@ -80,7 +80,7 @@ static int lookup_error(ToxWindow *self, const char *errmsg, ...)
     va_end(args);
 
     pthread_mutex_lock(&Winthread.lock);
-    line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "name lookup failed: %s", frmt_msg);
+    line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "name lookup failed: %s", frmt_msg);
     pthread_mutex_unlock(&Winthread.lock);
 
     return -1;
@@ -365,12 +365,12 @@ on_exit:
 void name_lookup(ToxWindow *self, Tox *m, const char *id_bin, const char *addr, const char *message)
 {
     if (t_data.disabled) {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "name lookups are disabled.");
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "name lookups are disabled.");
         return;
     }
 
     if (t_data.busy) {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Please wait for previous name lookup to finish.");
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Please wait for previous name lookup to finish.");
         return;
     }
 
@@ -382,20 +382,20 @@ void name_lookup(ToxWindow *self, Tox *m, const char *id_bin, const char *addr, 
     t_data.busy = true;
 
     if (pthread_attr_init(&lookup_thread.attr) != 0) {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, RED, "Error: lookup thread attr failed to init");
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, RED, "Error: lookup thread attr failed to init");
         clear_thread_data();
         return;
     }
 
     if (pthread_attr_setdetachstate(&lookup_thread.attr, PTHREAD_CREATE_DETACHED) != 0) {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, RED, "Error: lookup thread attr failed to set");
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, RED, "Error: lookup thread attr failed to set");
         pthread_attr_destroy(&lookup_thread.attr);
         clear_thread_data();
         return;
     }
 
     if (pthread_create(&lookup_thread.tid, &lookup_thread.attr, lookup_thread_func, NULL) != 0) {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, RED, "Error: lookup thread failed to init");
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, RED, "Error: lookup thread failed to init");
         pthread_attr_destroy(&lookup_thread.attr);
         clear_thread_data();
         return;

--- a/src/prompt.c
+++ b/src/prompt.c
@@ -144,7 +144,7 @@ void prompt_update_statusmessage(ToxWindow *prompt, Tox *m, const char *statusms
     tox_self_set_status_message(m, (const uint8_t *) statusmsg, len, &err);
 
     if (err != TOX_ERR_SET_INFO_OK) {
-        line_info_add(prompt, NULL, NULL, NULL, SYS_MSG, 0, 0, "Failed to set note (error %d)\n", err);
+        line_info_add(prompt, false, NULL, NULL, SYS_MSG, 0, 0, "Failed to set note (error %d)\n", err);
     }
 }
 
@@ -284,9 +284,9 @@ static bool prompt_onKey(ToxWindow *self, Tox *m, wint_t key, bool ltr)
             char line[MAX_STR_SIZE];
 
             if (wcs_to_mbs_buf(line, ctx->line, MAX_STR_SIZE) == -1) {
-                line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, RED, " * Failed to parse message.");
+                line_info_add(self, false, NULL, NULL, SYS_MSG, 0, RED, " * Failed to parse message.");
             } else {
-                line_info_add(self, NULL, NULL, NULL, PROMPT, 0, 0, "%s", line);
+                line_info_add(self, false, NULL, NULL, PROMPT, 0, 0, "%s", line);
                 execute(ctx->history, self, m, line, GLOBAL_COMMAND_MODE);
             }
         }
@@ -466,8 +466,6 @@ static void prompt_onConnectionChange(ToxWindow *self, Tox *m, uint32_t friendnu
         snprintf(nick, sizeof(nick), "%s", UNKNOWN_NAME);
     }
 
-    char timefrmt[TIME_STR_SIZE];
-    get_time_str(timefrmt, sizeof(timefrmt));
     const char *msg;
 
     if (user_settings->show_connection_msg == SHOW_WELCOME_MSG_OFF) {
@@ -476,7 +474,7 @@ static void prompt_onConnectionChange(ToxWindow *self, Tox *m, uint32_t friendnu
 
     if (connection_status != TOX_CONNECTION_NONE && Friends.list[friendnum].connection_status == TOX_CONNECTION_NONE) {
         msg = "has come online";
-        line_info_add(self, timefrmt, nick, NULL, CONNECTION, 0, GREEN, msg);
+        line_info_add(self, true, nick, NULL, CONNECTION, 0, GREEN, msg);
         write_to_log(msg, nick, ctx->log, true);
 
         if (self->active_box != -1) {
@@ -488,7 +486,7 @@ static void prompt_onConnectionChange(ToxWindow *self, Tox *m, uint32_t friendnu
         }
     } else if (connection_status == TOX_CONNECTION_NONE) {
         msg = "has gone offline";
-        line_info_add(self, timefrmt, nick, NULL, DISCONNECTION, 0, RED, msg);
+        line_info_add(self, true, nick, NULL, DISCONNECTION, 0, RED, msg);
         write_to_log(msg, nick, ctx->log, true);
 
         if (self->active_box != -1) {
@@ -508,21 +506,18 @@ static void prompt_onFriendRequest(ToxWindow *self, Tox *m, const char *key, con
 
     ChatContext *ctx = self->chatwin;
 
-    char timefrmt[TIME_STR_SIZE];
-    get_time_str(timefrmt, sizeof(timefrmt));
-
-    line_info_add(self, timefrmt, NULL, NULL, SYS_MSG, 0, 0, "Friend request with the message '%s'", data);
+    line_info_add(self, true, NULL, NULL, SYS_MSG, 0, 0, "Friend request with the message '%s'", data);
     write_to_log("Friend request with the message '%s'", "", ctx->log, true);
 
     int n = add_friend_request(key, data);
 
     if (n == -1) {
         const char *errmsg = "Friend request queue is full. Discarding request.";
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, errmsg);
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, errmsg);
         return;
     }
 
-    line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Type \"/accept %d\" or \"/decline %d\"", n, n);
+    line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Type \"/accept %d\" or \"/decline %d\"", n, n);
     sound_notify(self, generic_message, NT_WNDALERT_1 | NT_NOTIFWND, NULL);
 }
 
@@ -572,18 +567,18 @@ void prompt_init_statusbar(ToxWindow *self, Tox *m, bool first_time_run)
 
 static void print_welcome_msg(ToxWindow *self)
 {
-    line_info_add(self, NULL, NULL, NULL, SYS_MSG, 1, BLUE, "    _____ _____  _____ ____ ");
-    line_info_add(self, NULL, NULL, NULL, SYS_MSG, 1, BLUE, "   |_   _/ _ \\ \\/ /_ _/ ___|");
-    line_info_add(self, NULL, NULL, NULL, SYS_MSG, 1, BLUE, "     | || | | \\  / | | |    ");
-    line_info_add(self, NULL, NULL, NULL, SYS_MSG, 1, BLUE, "     | || |_| /  \\ | | |___ ");
-    line_info_add(self, NULL, NULL, NULL, SYS_MSG, 1, BLUE, "     |_| \\___/_/\\_\\___\\____| v." TOXICVER);
-    line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "");
+    line_info_add(self, false, NULL, NULL, SYS_MSG, 1, BLUE, "    _____ _____  _____ ____ ");
+    line_info_add(self, false, NULL, NULL, SYS_MSG, 1, BLUE, "   |_   _/ _ \\ \\/ /_ _/ ___|");
+    line_info_add(self, false, NULL, NULL, SYS_MSG, 1, BLUE, "     | || | | \\  / | | |    ");
+    line_info_add(self, false, NULL, NULL, SYS_MSG, 1, BLUE, "     | || |_| /  \\ | | |___ ");
+    line_info_add(self, false, NULL, NULL, SYS_MSG, 1, BLUE, "     |_| \\___/_/\\_\\___\\____| v." TOXICVER);
+    line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "");
 
     const char *msg = "Welcome to Toxic, a free, open source Tox-based instant messaging client.";
-    line_info_add(self, NULL, NULL, NULL, SYS_MSG, 1, CYAN, msg);
+    line_info_add(self, false, NULL, NULL, SYS_MSG, 1, CYAN, msg);
     msg = "Type \"/help\" for assistance. Further help may be found via the man page.";
-    line_info_add(self, NULL, NULL, NULL, SYS_MSG, 1, CYAN, msg);
-    line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "");
+    line_info_add(self, false, NULL, NULL, SYS_MSG, 1, CYAN, msg);
+    line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "");
 }
 
 static void prompt_init_log(ToxWindow *self, Tox *m, const char *self_name)
@@ -594,13 +589,13 @@ static void prompt_init_log(ToxWindow *self, Tox *m, const char *self_name)
     tox_self_get_address(m, (uint8_t *) myid);
 
     if (log_init(ctx->log, self->name, myid, NULL, LOG_TYPE_PROMPT) != 0) {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Warning: Log failed to initialize.");
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Warning: Log failed to initialize.");
         return;
     }
 
     if (user_settings->autolog == AUTOLOG_ON) {
         if (log_enable(ctx->log) == -1) {
-            line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Warning: Failed to enable log.");
+            line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Warning: Failed to enable log.");
         }
     }
 }

--- a/src/toxic.c
+++ b/src/toxic.c
@@ -1512,7 +1512,7 @@ int main(int argc, char **argv)
             pthread_mutex_lock(&Winthread.lock);
 
             if (store_data(m, DATA_FILE) != 0) {
-                line_info_add(prompt, NULL, NULL, NULL, SYS_MSG, 0, RED, "WARNING: Failed to save to data file");
+                line_info_add(prompt, false, NULL, NULL, SYS_MSG, 0, RED, "WARNING: Failed to save to data file");
             }
 
             pthread_mutex_unlock(&Winthread.lock);

--- a/src/video_call.c
+++ b/src/video_call.c
@@ -52,7 +52,7 @@ void on_video_bit_rate(ToxAV *av, uint32_t friend_number, uint32_t video_bit_rat
 
 static void print_err(ToxWindow *self, const char *error_str)
 {
-    line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "%s", error_str);
+    line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "%s", error_str);
 }
 
 ToxAV *init_video(ToxWindow *self, Tox *tox)
@@ -66,13 +66,13 @@ ToxAV *init_video(ToxWindow *self, Tox *tox)
     CallControl.video_frame_duration = 10;
 
     if (!CallControl.av) {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Video failed to init with ToxAV instance");
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Video failed to init with ToxAV instance");
 
         return NULL;
     }
 
     if (init_video_devices(CallControl.av) == vde_InternalError) {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Failed to init video devices");
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Failed to init video devices");
 
         return NULL;
     }
@@ -110,17 +110,17 @@ void read_video_device_callback(int16_t width, int16_t height, const uint8_t *y,
 
     /* Drop frame if video sending is disabled */
     if (this_call->video_bit_rate == 0 || this_call->status != cs_Active || this_call->vin_idx == -1) {
-        line_info_add(CallControl.prompt, NULL, NULL, NULL, SYS_MSG, 0, 0, "Video frame dropped.");
+        line_info_add(CallControl.prompt, false, NULL, NULL, SYS_MSG, 0, 0, "Video frame dropped.");
         return;
     }
 
     if (toxav_video_send_frame(CallControl.av, friend_number, width, height, y, u, v, &error) == false) {
-        line_info_add(CallControl.prompt, NULL, NULL, NULL, SYS_MSG, 0, 0, "Failed to send video frame");
+        line_info_add(CallControl.prompt, false, NULL, NULL, SYS_MSG, 0, 0, "Failed to send video frame");
 
         if (error == TOXAV_ERR_SEND_FRAME_NULL) {
-            line_info_add(CallControl.prompt, NULL, NULL, NULL, SYS_MSG, 0, 0, "Failed to capture video frame");
+            line_info_add(CallControl.prompt, false, NULL, NULL, SYS_MSG, 0, 0, "Failed to capture video frame");
         } else if (error == TOXAV_ERR_SEND_FRAME_INVALID) {
-            line_info_add(CallControl.prompt, NULL, NULL, NULL, SYS_MSG, 0, 0, "Failed to prepare video frame");
+            line_info_add(CallControl.prompt, false, NULL, NULL, SYS_MSG, 0, 0, "Failed to prepare video frame");
         }
     }
 }
@@ -138,22 +138,22 @@ void write_video_device_callback(uint32_t friend_number, uint16_t width, uint16_
 int start_video_transmission(ToxWindow *self, ToxAV *av, Call *call)
 {
     if (!self || !av) {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Failed to prepare video transmission");
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Failed to prepare video transmission");
         return -1;
     }
 
     if (open_primary_video_device(vdt_input, &call->vin_idx, &call->video_width, &call->video_height) != vde_None) {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Failed to open input video device!");
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Failed to open input video device!");
         return -1;
     }
 
     if (register_video_device_callback(self->num, call->vin_idx, read_video_device_callback, &self->num) != vde_None) {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Failed to register input video handler!");
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Failed to register input video handler!");
         return -1;
     }
 
     if (!toxav_video_set_bit_rate(CallControl.av, self->num, call->video_bit_rate, NULL)) {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Failed to set video bit rate");
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Failed to set video bit rate");
         return -1;
     }
 
@@ -347,11 +347,11 @@ void cmd_res(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[MAX
 
     if (argc == 0) {
         if (call->status == cs_Active && call->vin_idx != -1) {
-            line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0,
+            line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0,
                           "Resolution of current call: %u x %u",
                           call->video_width, call->video_height);
         } else {
-            line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0,
+            line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0,
                           "Initial resolution for video calls: %u x %u",
                           CallControl.default_video_width, CallControl.default_video_height);
         }
@@ -411,7 +411,7 @@ void cmd_list_video_devices(WINDOW *window, ToxWindow *self, Tox *m, int argc, c
     }
 
     else {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Invalid type: %s", argv[1]);
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Invalid type: %s", argv[1]);
         return;
     }
 
@@ -447,7 +447,7 @@ void cmd_change_video_device(WINDOW *window, ToxWindow *self, Tox *m, int argc, 
     }
 
     else {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "Invalid type: %s", argv[1]);
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Invalid type: %s", argv[1]);
         return;
     }
 

--- a/src/video_device.c
+++ b/src/video_device.c
@@ -852,7 +852,7 @@ void print_video_devices(ToxWindow *self, VideoDeviceType type)
     int i;
 
     for (i = 0; i < size[type]; ++i) {
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "%d: %s", i, video_devices_names[type][i]);
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "%d: %s", i, video_devices_names[type][i]);
     }
 
     return;


### PR DESCRIPTION
Instead of making the caller of `line_info_add` provide a timestamp string we just have them set a boolean value and let the callee create the string.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxic/163)
<!-- Reviewable:end -->
