### PR TITLE
fix: Makefile assignment bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,8 @@ else
 endif
 
 # Check if LLVM Address Sanitizer is enabled
-ENABLE_ASAN := $(shell if [ -z "$(ENABLE_ASAN)" ] || [ "$(ENABLE_ASAN)" = "0" ] ; then echo disabled ; else echo enabled ; fi)
-ifneq ($(ENABLE_ASAN), disabled)
+ASAN := $(shell if [ -z "$(ENABLE_ASAN)" ] || [ "$(ENABLE_ASAN)" = "0" ] ; then echo disabled ; else echo enabled ; fi)
+ifneq ($(ASAN), disabled)
 	CFLAGS += -fsanitize=address -fno-omit-frame-pointer
 endif
 


### PR DESCRIPTION
When a user provides variable=value as an argument to make, all
assignments to that variable are ignored within the Makefile because the
user has explicitly overrode variable to be "value". This made the
ENABLE_ASAN assignment to be ignored, resulting in Toxic always enabling
ASAN unless you run `make ENABLE_ASAN=disabled`, which is not
documented and not how it's intended to work. This can be fixed by
prefixing the assignment with "override", but to be in line with other
argument assignments we just change the variable name.

See more at:
https://www.gnu.org/software/make/manual/html_node/Overriding.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxic/178)
<!-- Reviewable:end -->
