### PR TITLE
fix: half-fix a serious display bug related to unicode char printing

### DIFF
--- a/src/line_info.c
+++ b/src/line_info.c
@@ -239,11 +239,6 @@ static int print_wrap(WINDOW *win, struct line_info *line, int max_x, int max_y)
     while (msg) {
         getyx(win, y, x);
 
-        // next line would print past window limit so we abort; we don't want to update format_lines
-        if (x > x_start) {
-            return -1;
-        }
-
         if (length < x_limit) {
             int p_ret = print_n_chars(win, msg, length, max_y);
 


### PR DESCRIPTION
Due to toxic being unable to know the screen width of a given unicode character, line
printing becomes buggy when certain unicode characters are used. Rather than returning
an error and printing empty lines when a length error is detected, we now just deal
with a less-bad bug that causes the line not to wrap correctly, and the window not to
scroll the correct number of lines.

This is not ideal behaviour, but it's better than having the interface completely break,
which is particularly bad when logs are enabled, as simply closing and re-opening the
window would not fix the issue.

An ideal fix for this problem would be to calculate the correct screen-width of a line
before printing it. However this is easier said than done given toxic's hacky display

edit: This actually breaks other things as well, I don't think this PR meets quality standards

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxic/181)
<!-- Reviewable:end -->
