### PR TITLE
fix: buggy behaviour when printing non-ascii characters in Home input field

### DIFF
--- a/src/prompt.c
+++ b/src/prompt.c
@@ -324,8 +324,6 @@ static void prompt_onDraw(ToxWindow *self, Tox *m)
         mvwprintw(ctx->linewin, 0, 0, "%ls", &ctx->line[ctx->start]);
     }
 
-    mvwhline(ctx->linewin, 0, ctx->len, ' ', x2 - ctx->len);
-
     curs_set(1);
 
     StatusBar *statusbar = self->stb;


### PR DESCRIPTION
This line doesn't appear to be doing anything useful - most likely a leftover from the recent UI overhaul

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxic/183)
<!-- Reviewable:end -->
