### PR TITLE
fix: Add two missing mutex unlocks before return

### DIFF
--- a/src/audio_device.c
+++ b/src/audio_device.c
@@ -575,6 +575,7 @@ DeviceError close_device(DeviceType type, uint32_t device_idx)
     Device *device = &audio_state->devices[type][device_idx];
 
     if (!device->active) {
+        unlock(type);
         return de_DeviceNotActive;
     }
 

--- a/src/notify.c
+++ b/src/notify.c
@@ -707,6 +707,7 @@ int box_notify(ToxWindow *self, Notification notif, uint64_t flags, int *id_indi
 #else
 
     if (id == -1) {
+        control_unlock();
         return -1;
     }
 


### PR DESCRIPTION
Possible fix for https://github.com/TokTok/toxic/issues/184

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxic/185)
<!-- Reviewable:end -->
