### PR TITLE
chore: Add a bazel test that calls toxic with `--help`.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -39,3 +39,9 @@ cc_binary(
         "//tools/config:osx": [],
     }),
 )
+
+sh_test(
+    name = "toxic_test",
+    srcs = [":toxic"],
+    args = ["--help"],
+)


### PR DESCRIPTION
This way we at least know it doesn't crash on load. Some code runs. We'll
want some real tests at some point, but this ensures *something* works.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxic/194)
<!-- Reviewable:end -->
