### PR TITLE
cleanup: Reduce the amount of "extern" in .c files.

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -41,9 +41,6 @@ Tox              *user_tox;
 static WINDOW    *cur_window;
 static ToxWindow *self_window;
 
-extern FriendsList Friends;
-extern struct user_settings *user_settings;
-
 void api_display(const char *const msg)
 {
     if (msg == NULL) {

--- a/src/audio_call.c
+++ b/src/audio_call.c
@@ -60,13 +60,7 @@
 #endif /* ALC_ALL_DEVICES_SPECIFIER */
 #endif /* __APPLE__ */
 
-extern FriendsList Friends;
-extern ToxWindow *windows[MAX_WINDOWS_NUM];
-
 struct CallControl CallControl;
-
-extern struct user_settings *user_settings;
-extern struct Winthread Winthread;
 
 void on_call(ToxAV *av, uint32_t friend_number, bool audio_enabled, bool video_enabled,
              void *user_data);

--- a/src/bootstrap.c
+++ b/src/bootstrap.c
@@ -39,9 +39,7 @@
 #include "settings.h"
 #include "windows.h"
 
-extern struct arg_opts arg_opts;
 extern struct user_settings *user_settings;
-extern struct Winthread Winthread;
 
 /* URL that we get the JSON encoded nodes list from. */
 #define NODES_LIST_URL "https://nodes.tox.chat/json"
@@ -59,7 +57,6 @@ extern struct Winthread Winthread;
 
 #define IP_MAX_SIZE 45
 #define IP_MIN_SIZE 7
-#define PORT_MAX_SIZE 5
 
 #define LAST_SCAN_JSON_KEY "\"last_scan\":"
 #define LAST_SCAN_JSON_KEY_LEN (sizeof(LAST_SCAN_JSON_KEY) - 1)

--- a/src/chat.c
+++ b/src/chat.c
@@ -58,12 +58,6 @@
 #endif /* VIDEO */
 #endif /* AUDIO */
 
-extern char *DATA_FILE;
-extern FriendsList Friends;
-
-extern struct Winthread Winthread;
-extern struct user_settings *user_settings;
-
 #ifdef AUDIO
 static void init_infobox(ToxWindow *self);
 static void kill_infobox(ToxWindow *self);

--- a/src/conference.c
+++ b/src/conference.c
@@ -63,8 +63,6 @@
 #include "toxic_strings.h"
 #include "windows.h"
 
-extern char *DATA_FILE;
-
 #define MAX_CONFERENCE_NUM (MAX_WINDOWS_NUM - 2)
 #define CONFERENCE_EVENT_WAIT 30
 

--- a/src/friendlist.c
+++ b/src/friendlist.c
@@ -37,6 +37,7 @@
 #include "log.h"
 #include "misc_tools.h"
 #include "notify.h"
+#include "prompt.h"
 #include "settings.h"
 #include "toxic.h"
 #include "windows.h"
@@ -45,13 +46,6 @@
 #include "audio_call.h"
 #endif
 
-
-extern char *DATA_FILE;
-extern char *BLOCK_FILE;
-extern ToxWindow *prompt;
-extern struct Winthread Winthread;
-extern struct user_settings *user_settings;
-extern struct arg_opts arg_opts;
 
 static uint8_t blocklist_view = 0;   /* 0 if we're in friendlist view, 1 if we're in blocklist view */
 

--- a/src/friendlist.h
+++ b/src/friendlist.h
@@ -101,6 +101,8 @@ typedef struct {
     ToxicFriend *list;
 } FriendsList;
 
+extern FriendsList Friends;
+
 ToxWindow *new_friendlist(void);
 void friendlist_onInit(ToxWindow *self, Tox *m);
 void disable_chatwin(uint32_t f_num);

--- a/src/global_commands.c
+++ b/src/global_commands.c
@@ -42,11 +42,6 @@
 #include "game_base.h"
 #endif
 
-extern char *DATA_FILE;
-extern ToxWindow *prompt;
-extern FriendsList Friends;
-extern FriendRequests FrndRequests;
-
 /* command functions */
 void cmd_accept(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[MAX_STR_SIZE])
 {

--- a/src/name_lookup.c
+++ b/src/name_lookup.c
@@ -33,9 +33,6 @@
 #include "toxic.h"
 #include "windows.h"
 
-extern struct arg_opts arg_opts;
-extern struct Winthread Winthread;
-
 #define NAMESERVER_API_PATH "api"
 #define SERVER_KEY_SIZE 32
 #define MAX_SERVERS 50

--- a/src/prompt.h
+++ b/src/prompt.h
@@ -40,6 +40,9 @@ typedef struct FriendRequests {
     struct friend_request request[MAX_FRIEND_REQUESTS];
 } FriendRequests;
 
+extern ToxWindow *prompt;
+extern FriendRequests FrndRequests;
+
 ToxWindow *new_prompt(void);
 
 void prep_prompt_win(void);

--- a/src/settings.h
+++ b/src/settings.h
@@ -96,6 +96,8 @@ struct user_settings {
 #endif
 };
 
+extern struct user_settings *user_settings;
+
 enum settings_values {
     AUTOLOG_OFF = 0,
     AUTOLOG_ON = 1,

--- a/src/toxic.c
+++ b/src/toxic.c
@@ -74,7 +74,7 @@
 #ifdef VIDEO
 #include "video_call.h"
 #endif /* VIDEO */
-ToxAV *av;
+static ToxAV *av;
 #endif /* AUDIO */
 
 #ifdef PYTHON
@@ -98,8 +98,8 @@ ToxWindow *prompt = NULL;
 #define MAX_PASSWORD_LEN 64
 
 struct Winthread Winthread;
-struct cqueue_thread cqueue_thread;
-struct av_thread av_thread;
+static struct cqueue_thread cqueue_thread;
+static struct av_thread av_thread;
 struct arg_opts arg_opts;
 
 // This struct is not thread safe. It should only ever be written to from the main thread

--- a/src/toxic.h
+++ b/src/toxic.h
@@ -145,5 +145,7 @@ void on_friend_typing(Tox *m, uint32_t friendnumber, bool is_typing, void *userd
 void on_friend_read_receipt(Tox *m, uint32_t friendnumber, uint32_t receipt, void *userdata);
 void on_lossless_custom_packet(Tox *m, uint32_t friendnumber, const uint8_t *data, size_t length, void *userdata);
 
+extern char *DATA_FILE;
+extern char *BLOCK_FILE;
 
 #endif /* TOXIC_H */

--- a/src/video_device.c
+++ b/src/video_device.c
@@ -92,21 +92,21 @@ typedef struct VideoDevice {
 
 } VideoDevice;
 
-const char *dvideo_device_names[2];              /* Default device */
-char *video_devices_names[2][MAX_DEVICES]; /* Container of available devices */
-static int size[2];                        /* Size of above containers */
-VideoDevice *video_devices_running[2][MAX_DEVICES] = {{NULL}};     /* Running devices */
-uint32_t primary_video_device[2];          /* Primary device */
+static const char *dvideo_device_names[2];        /* Default device */
+static char *video_devices_names[2][MAX_DEVICES]; /* Container of available devices */
+static int size[2];                               /* Size of above containers */
+static VideoDevice *video_devices_running[2][MAX_DEVICES] = {{NULL}}; /* Running devices */
+static uint32_t primary_video_device[2];                              /* Primary device */
 
 static ToxAV *av = NULL;
 
 /* q_mutex */
 #define lock pthread_mutex_lock(&video_mutex)
 #define unlock pthread_mutex_unlock(&video_mutex)
-pthread_mutex_t video_mutex;
+static pthread_mutex_t video_mutex;
 
-bool video_thread_running = true,
-     video_thread_paused = true;                /* Thread control */
+static bool video_thread_running = true;
+static bool video_thread_paused = true;                /* Thread control */
 
 void *video_thread_poll(void *);
 

--- a/src/windows.c
+++ b/src/windows.c
@@ -41,15 +41,9 @@
 #include "game_base.h"
 #endif
 
-extern char *DATA_FILE;
-extern struct Winthread Winthread;
-
 ToxWindow *windows[MAX_WINDOWS_NUM];
 static uint8_t active_window_index;
 static int num_active_windows;
-
-extern ToxWindow *prompt;
-extern struct user_settings *user_settings;
 
 /* CALLBACKS START */
 void on_friend_request(Tox *m, const uint8_t *public_key, const uint8_t *data, size_t length, void *userdata)

--- a/src/windows.h
+++ b/src/windows.h
@@ -114,6 +114,8 @@ struct Winthread {
     volatile sig_atomic_t last_refresh_flag;
 };
 
+extern struct Winthread Winthread;
+
 struct cqueue_thread {
     pthread_t tid;
 };
@@ -146,6 +148,8 @@ struct arg_opts {
 
     uint16_t tcp_port;
 };
+
+extern struct arg_opts arg_opts;
 
 typedef struct ToxWindow ToxWindow;
 typedef struct StatusBar StatusBar;
@@ -232,6 +236,8 @@ struct ToxWindow {
     WINDOW *window;
     WINDOW *window_bar;
 };
+
+extern ToxWindow *windows[MAX_WINDOWS_NUM];
 
 /* statusbar info holder */
 struct StatusBar {


### PR DESCRIPTION
There is no check at all that the types of externs actually match the
type of the definition. This just accidentally was not a problem, but now
the compiler helps a bit in keeping it that way.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxic/199)
<!-- Reviewable:end -->
