### PR TITLE
feat: Implement file transfer queue for offline friends

### DIFF
--- a/src/chat.c
+++ b/src/chat.c
@@ -248,6 +248,7 @@ static void chat_onConnectionChange(ToxWindow *self, Tox *m, uint32_t num, Tox_C
 
     if (prev_status == TOX_CONNECTION_NONE) {
         chat_resume_file_senders(self, m, num);
+        file_send_queue_check(self, m, self->num);
 
         msg = "has come online";
         line_info_add(self, true, nick, NULL, CONNECTION, 0, GREEN, msg);

--- a/src/friendlist.c
+++ b/src/friendlist.c
@@ -1107,14 +1107,14 @@ static void friendlist_onDraw(ToxWindow *self, Tox *m)
 
     /* Determine which portion of friendlist to draw based on current position */
     pthread_mutex_lock(&Winthread.lock);
-    int page = Friends.num_selected / (y2 - FLIST_OFST);
+    const int page = Friends.num_selected / (y2 - FLIST_OFST);
     pthread_mutex_unlock(&Winthread.lock);
 
-    int start = (y2 - FLIST_OFST) * page;
-    int end = y2 - FLIST_OFST + start;
+    const int start = (y2 - FLIST_OFST) * page;
+    const int end = y2 - FLIST_OFST + start;
 
     pthread_mutex_lock(&Winthread.lock);
-    size_t num_friends = Friends.num_friends;
+    const size_t num_friends = Friends.num_friends;
     pthread_mutex_unlock(&Winthread.lock);
 
     int i;

--- a/src/friendlist.h
+++ b/src/friendlist.h
@@ -79,8 +79,9 @@ typedef struct {
     struct GameInvite game_invite;
 #endif
 
-    struct FileTransfer file_receiver[MAX_FILES];
-    struct FileTransfer file_sender[MAX_FILES];
+    FileTransfer file_receiver[MAX_FILES];
+    FileTransfer file_sender[MAX_FILES];
+    PendingFileTransfer file_send_queue[MAX_FILES];
 } ToxicFriend;
 
 typedef struct {

--- a/src/windows.c
+++ b/src/windows.c
@@ -244,7 +244,7 @@ void on_file_chunk_request(Tox *m, uint32_t friendnumber, uint32_t filenumber, u
 {
     UNUSED_VAR(userdata);
 
-    struct FileTransfer *ft = get_file_transfer_struct(friendnumber, filenumber);
+    FileTransfer *ft = get_file_transfer_struct(friendnumber, filenumber);
 
     if (!ft) {
         return;
@@ -267,7 +267,7 @@ void on_file_recv_chunk(Tox *m, uint32_t friendnumber, uint32_t filenumber, uint
 {
     UNUSED_VAR(userdata);
 
-    struct FileTransfer *ft = get_file_transfer_struct(friendnumber, filenumber);
+    FileTransfer *ft = get_file_transfer_struct(friendnumber, filenumber);
 
     if (!ft) {
         return;
@@ -285,7 +285,7 @@ void on_file_recv_control(Tox *m, uint32_t friendnumber, uint32_t filenumber, To
 {
     UNUSED_VAR(userdata);
 
-    struct FileTransfer *ft = get_file_transfer_struct(friendnumber, filenumber);
+    FileTransfer *ft = get_file_transfer_struct(friendnumber, filenumber);
 
     if (!ft) {
         return;


### PR DESCRIPTION
File transfers initiated for offline friends are now added to a queue and initiated all at once when the friend appears online.

I also did a little code cleanup in this PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxic/208)
<!-- Reviewable:end -->
