### PR TITLE
fix: make sure we check for duplicate paths in pending file transfers list

### DIFF
--- a/src/chat.c
+++ b/src/chat.c
@@ -676,8 +676,10 @@ static void chat_onFileRecv(ToxWindow *self, Tox *m, uint32_t friendnum, uint32_
     FILE *filecheck = NULL;
     int count = 1;
 
-    while ((filecheck = fopen(file_path, "r"))) {
-        fclose(filecheck);
+    while ((filecheck = fopen(file_path, "r")) || file_transfer_recv_path_exists(file_path)) {
+        if (filecheck) {
+            fclose(filecheck);
+        }
 
         file_path[path_len] = '\0';
         char d[5];

--- a/src/file_transfers.c
+++ b/src/file_transfers.c
@@ -45,9 +45,8 @@ extern FriendsList Friends;
 void init_progress_bar(char *progline)
 {
     strcpy(progline, "0% [");
-    int i;
 
-    for (i = 0; i < NUM_PROG_MARKS; ++i) {
+    for (size_t i = 0; i < NUM_PROG_MARKS; ++i) {
         strcat(progline, "-");
     }
 
@@ -396,4 +395,27 @@ void kill_all_file_transfers(Tox *m)
     for (size_t i = 0; i < Friends.max_idx; ++i) {
         kill_all_file_transfers_friend(m, Friends.list[i].num);
     }
+}
+
+bool file_transfer_recv_path_exists(const char *path)
+{
+    for (size_t friendnumber = 0; friendnumber < Friends.max_idx; ++friendnumber) {
+        if (!Friends.list[friendnumber].active) {
+            continue;
+        }
+
+        for (size_t i = 0; i < MAX_FILES; ++i) {
+            FileTransfer *ft = &Friends.list[friendnumber].file_receiver[i];
+
+            if (ft->state == FILE_TRANSFER_INACTIVE) {
+                continue;
+            }
+
+            if (strcmp(path, ft->file_path) == 0) {
+                return true;
+            }
+        }
+    }
+
+    return false;
 }

--- a/src/file_transfers.h
+++ b/src/file_transfers.h
@@ -145,4 +145,7 @@ void kill_all_file_transfers_friend(Tox *m, uint32_t friendnumber);
 
 void kill_all_file_transfers(Tox *m);
 
+/* Return true if any pending or active file receiver has the path `path`. */
+bool file_transfer_recv_path_exists(const char *path);
+
 #endif /* FILE_TRANSFERS_H */


### PR DESCRIPTION
This fixes a bug where if you receive multiple file transfer requests simultaneously and they have the same path the files will overwrite each other.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxic/214)
<!-- Reviewable:end -->
