### PR TITLE
feat: add some simple impersonation detection on friend requests

### DIFF
--- a/src/chat.c
+++ b/src/chat.c
@@ -1385,7 +1385,7 @@ static void chat_onDraw(ToxWindow *self, Tox *m)
     self->x = x2;
 
     /* Truncate note if it doesn't fit in statusbar */
-    size_t maxlen = x2 - getcurx(statusbar->topline) - (KEY_IDENT_DIGITS * 2) - 6;
+    size_t maxlen = x2 - getcurx(statusbar->topline) - KEY_IDENT_BYTES - 6;
 
     pthread_mutex_lock(&Winthread.lock);
     size_t statusmsg_len = statusbar->statusmsg_len;
@@ -1416,10 +1416,10 @@ static void chat_onDraw(ToxWindow *self, Tox *m)
     int s_x;
     getyx(statusbar->topline, s_y, s_x);
 
-    mvwhline(statusbar->topline, s_y, s_x, ' ', x2 - s_x - (KEY_IDENT_DIGITS * 2) - 3);
+    mvwhline(statusbar->topline, s_y, s_x, ' ', x2 - s_x - KEY_IDENT_BYTES  - 3);
     wattroff(statusbar->topline, COLOR_PAIR(BAR_TEXT));
 
-    wmove(statusbar->topline, 0, x2 - (KEY_IDENT_DIGITS * 2) - 3);
+    wmove(statusbar->topline, 0, x2 - KEY_IDENT_BYTES  - 3);
 
     wattron(statusbar->topline, COLOR_PAIR(BAR_ACCENT));
     wprintw(statusbar->topline, "{");
@@ -1427,7 +1427,7 @@ static void chat_onDraw(ToxWindow *self, Tox *m)
 
     wattron(statusbar->topline, COLOR_PAIR(BAR_TEXT));
 
-    for (size_t i = 0; i < KEY_IDENT_DIGITS; ++i) {
+    for (size_t i = 0; i < KEY_IDENT_BYTES / 2; ++i) {
         wprintw(statusbar->topline, "%02X", Friends.list[self->num].pub_key[i] & 0xff);
     }
 

--- a/src/log.c
+++ b/src/log.c
@@ -62,21 +62,21 @@ static int get_log_path(char *dest, int destsize, const char *name, const char *
 
     /* first 6 bytes of selfkey */
     char self_id[32] = {0};
-    path_len += KEY_IDENT_DIGITS * 2;
+    path_len += KEY_IDENT_BYTES;
     sprintf(&self_id[0], "%02X", selfkey[0] & 0xff);
     sprintf(&self_id[2], "%02X", selfkey[1] & 0xff);
     sprintf(&self_id[4], "%02X", selfkey[2] & 0xff);
-    self_id[KEY_IDENT_DIGITS * 2] = '\0';
+    self_id[KEY_IDENT_BYTES] = '\0';
 
     char other_id[32] = {0};
 
     if (otherkey) {
         /* first 6 bytes of otherkey */
-        path_len += KEY_IDENT_DIGITS * 2;
+        path_len += KEY_IDENT_BYTES;
         sprintf(&other_id[0], "%02X", otherkey[0] & 0xff);
         sprintf(&other_id[2], "%02X", otherkey[1] & 0xff);
         sprintf(&other_id[4], "%02X", otherkey[2] & 0xff);
-        other_id[KEY_IDENT_DIGITS * 2] = '\0';
+        other_id[KEY_IDENT_BYTES] = '\0';
     }
 
     if (path_len >= destsize) {

--- a/src/toxic.h
+++ b/src/toxic.h
@@ -46,7 +46,7 @@
 #define MAX_STR_SIZE TOX_MAX_MESSAGE_LENGTH    /* must be >= TOX_MAX_MESSAGE_LENGTH */
 #define MAX_CMDNAME_SIZE 64
 #define TOXIC_MAX_NAME_LENGTH 32   /* Must be <= TOX_MAX_NAME_LENGTH */
-#define KEY_IDENT_DIGITS 3    /* number of hex digits to display for the pub-key based identifier */
+#define KEY_IDENT_BYTES 6    /* number of hex digits to display for the public key identifier */
 #define TIME_STR_SIZE 32
 #define COLOR_STR_SIZE 10 /* should fit every color option */
 


### PR DESCRIPTION
This will alert the user when the first three bytes of a new contact's public key is the same as any other contact in their list. These 3 bytes are used elsewhere in toxic for unique identification.

Also did a small refactor regarding the KEY_IDENT_BYTES define.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxic/215)
<!-- Reviewable:end -->
