### PR TITLE
fix: use widechars to display strings in the UI

### DIFF
--- a/src/line_info.h
+++ b/src/line_info.h
@@ -46,11 +46,11 @@ typedef enum LINE_TYPE {
 } LINE_TYPE;
 
 struct line_info {
-    char timestr[TIME_STR_SIZE];
-    char name1[TOXIC_MAX_NAME_LENGTH + 1];
-    char name2[TOXIC_MAX_NAME_LENGTH + 1];
-    char msg[MAX_LINE_INFO_MSG_SIZE];
-    time_t timestamp;
+    char    timestr[TIME_STR_SIZE];
+    char    name1[TOXIC_MAX_NAME_LENGTH + 1];
+    char    name2[TOXIC_MAX_NAME_LENGTH + 1];
+    wchar_t msg[MAX_LINE_INFO_MSG_SIZE];
+    time_t  timestamp;
     uint8_t type;
     uint8_t bold;
     uint8_t colour;
@@ -58,7 +58,7 @@ struct line_info {
     bool    read_flag;     /* true if a message has been flagged as read */
     uint32_t id;
     uint16_t len;        /* combined length of entire line */
-    uint16_t msg_len;    /* length of the message */
+    uint16_t msg_width;    /* width of the message */
     uint16_t format_lines;  /* number of lines the combined string takes up (dynamically set) */
 
     struct line_info *prev;

--- a/src/toxic.h
+++ b/src/toxic.h
@@ -23,6 +23,10 @@
 #ifndef TOXIC_H
 #define TOXIC_H
 
+#ifndef NCURSES_WIDECHAR
+#define NCURSES_WIDECHAR 1
+#endif
+
 #ifndef TOXICVER
 #define TOXICVER "NOVERS"    /* Use the -D flag to set this */
 #endif


### PR DESCRIPTION
This fixes a bug where printing a bunch of UTF8 chars with glyphs that have a size > 1 would make the entire chat window disappear. It also fixes an issue where said UTF8 chars would be truncated and generally not display correctly.

UTF8 printing is still not perfect, but this is a big improvement.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxic/216)
<!-- Reviewable:end -->
