### PR TITLE
cleanup: make sure we compare wchars to wchars instead of bytes

### DIFF
--- a/src/line_info.c
+++ b/src/line_info.c
@@ -593,22 +593,22 @@ void line_info_print(ToxWindow *self)
                 wprintw(win, "%s %s: ", user_settings->line_normal, line->name1);
                 wattroff(win, COLOR_PAIR(nameclr));
 
-                if (line->msg[0] == 0) {
+                if (line->msg[0] == L'\0') {
                     waddch(win, '\n');
                     break;
                 }
 
-                if (line->msg[0] == '>') {
+                if (line->msg[0] == L'>') {
                     wattron(win, COLOR_PAIR(GREEN));
-                } else if (line->msg[0] == '<') {
+                } else if (line->msg[0] == L'<') {
                     wattron(win, COLOR_PAIR(RED));
                 }
 
                 print_wrap(win, line, max_x, max_y);
 
-                if (line->msg[0] == '>') {
+                if (line->msg[0] == L'>') {
                     wattroff(win, COLOR_PAIR(GREEN));
-                } else if (line->msg[0] == '<') {
+                } else if (line->msg[0] == L'<') {
                     wattroff(win, COLOR_PAIR(RED));
                 }
 
@@ -667,7 +667,7 @@ void line_info_print(ToxWindow *self)
                 wprintw(win, "$ ");
                 wattroff(win, COLOR_PAIR(GREEN));
 
-                if (line->msg[0]) {
+                if (line->msg[0] != L'\0') {
                     print_wrap(win, line, max_x, max_y);
                 }
 


### PR DESCRIPTION
The msg buffer was recently changed to wchar_t and I forgot about these comparisons.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxic/219)
<!-- Reviewable:end -->
