### PR TITLE
fix: bug causing messages containing newline byte to disappear

### DIFF
--- a/src/line_info.c
+++ b/src/line_info.c
@@ -345,22 +345,25 @@ static uint16_t line_info_add_msg(wchar_t *buf, size_t buf_size, const char *msg
         return 0;
     }
 
-    uint16_t width = 0;
-
     const wint_t wc_msg_len = mbs_to_wcs_buf(buf, msg, buf_size);
 
     if (wc_msg_len > 0 && wc_msg_len < buf_size) {
         buf[wc_msg_len] = L'\0';
-        width = (uint16_t) wcswidth(buf, wc_msg_len);
+        int width = wcswidth(buf, wc_msg_len);
+
+        if (width == -1) {  // the best we can do on failure is to fall back to strlen
+            width = strlen(msg);
+        }
+
+        return (uint16_t)width;
     } else {
         fprintf(stderr, "Failed to convert string '%s' to widechar\n", msg);
         const wchar_t *err = L"Failed to parse message";
-        width = wcslen(err);
+        uint16_t width = (uint16_t)wcslen(err);
         wmemcpy(buf, err, width);
         buf[width] = L'\0';
+        return width;
     }
-
-    return width;
 }
 
 static void line_info_init_line(ToxWindow *self, struct line_info *line)

--- a/src/misc_tools.c
+++ b/src/misc_tools.c
@@ -477,10 +477,9 @@ on_error:
    returns length of msg, which will be no larger than size-1 */
 size_t copy_tox_str(char *msg, size_t size, const char *data, size_t length)
 {
-    size_t i;
     size_t j = 0;
 
-    for (i = 0; (i < length) && (j < size - 1); ++i) {
+    for (size_t i = 0; (i < length) && (j < size - 1); ++i) {
         if (data[i] != '\r') {
             msg[j++] = data[i];
         }


### PR DESCRIPTION
The wcswidth() function was silently failing when trying to convert
messages containing a newline to a widechar buffer which resulted
in the message showing up as an empty line. we now fall back
to using strlen to get the width of the string, which might still
cause minor display bugs when the message contains unicode, but is
still better than losing messages entirely.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxic/222)
<!-- Reviewable:end -->
