### PR TITLE
cleanup: Remove all uses of deprecated enum names.

### DIFF
--- a/src/chat.c
+++ b/src/chat.c
@@ -130,7 +130,7 @@ static void set_self_typingstatus(ToxWindow *self, Tox *m, bool is_typing)
 
     ChatContext *ctx = self->chatwin;
 
-    TOX_ERR_SET_TYPING err;
+    Tox_Err_Set_Typing err;
     tox_self_set_typing(m, self->num, is_typing, &err);
 
     if (err != TOX_ERR_SET_TYPING_OK) {

--- a/src/game_base.c
+++ b/src/game_base.c
@@ -1129,7 +1129,7 @@ int game_packet_send(const GameData *game, const uint8_t *data, size_t length, G
     memcpy(packet + 1 + GAME_PACKET_HEADER_SIZE, data, length);
     packet_length += length;
 
-    TOX_ERR_FRIEND_CUSTOM_PACKET err;
+    Tox_Err_Friend_Custom_Packet err;
 
     if (!tox_friend_send_lossless_packet(game->tox, game->friend_number, packet, packet_length, &err)) {
         fprintf(stderr, "failed to send game packet: error %d\n", err);

--- a/src/message_queue.c
+++ b/src/message_queue.c
@@ -203,7 +203,7 @@ void cqueue_try_send(ToxWindow *self, Tox *m)
             return;
         }
 
-        TOX_ERR_FRIEND_SEND_MESSAGE err;
+        Tox_Err_Friend_Send_Message err;
         Tox_Message_Type type = msg->type == OUT_MSG ? TOX_MESSAGE_TYPE_NORMAL : TOX_MESSAGE_TYPE_ACTION;
         uint32_t receipt = tox_friend_send_message(m, self->num, type, (uint8_t *) msg->message, msg->len, &err);
 

--- a/src/toxic.c
+++ b/src/toxic.c
@@ -229,7 +229,7 @@ void exit_toxic_err(const char *errmsg, int errcode)
     exit(EXIT_FAILURE);
 }
 
-void cb_toxcore_logger(Tox *m, TOX_LOG_LEVEL level, const char *file, uint32_t line, const char *func,
+void cb_toxcore_logger(Tox *m, Tox_Log_Level level, const char *file, uint32_t line, const char *func,
                        const char *message, void *user_data)
 {
     UNUSED_VAR(user_data);


### PR DESCRIPTION
All-caps enum names have been deprecated for a while now and will go
away in 0.3.0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxic/224)
<!-- Reviewable:end -->
