### PR TITLE
fix: Use calloc instead of malloc for new message queue items

### DIFF
--- a/src/message_queue.c
+++ b/src/message_queue.c
@@ -48,7 +48,7 @@ void cqueue_add(struct chat_queue *q, const char *msg, size_t len, uint8_t type,
         return;
     }
 
-    struct cqueue_msg *new_m = malloc(sizeof(struct cqueue_msg));
+    struct cqueue_msg *new_m = calloc(1, sizeof(struct cqueue_msg));
 
     if (new_m == NULL) {
         exit_toxic_err("failed in cqueue_message", FATALERR_MEMORY);
@@ -62,6 +62,7 @@ void cqueue_add(struct chat_queue *q, const char *msg, size_t len, uint8_t type,
     new_m->time_added = get_unix_time();
     new_m->receipt = -1;
     new_m->next = NULL;
+    new_m->noread_flag = false;
 
     if (q->root == NULL) {
         new_m->prev = NULL;


### PR DESCRIPTION
This prevents us from accidentally using uninitialized memory

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxic/227)
<!-- Reviewable:end -->
