### PR TITLE
fix: group ignore functionality

### DIFF
--- a/script/build-minimal-static-toxic.sh
+++ b/script/build-minimal-static-toxic.sh
@@ -277,6 +277,7 @@ echo '#!/usr/bin/env sh
 DEBIAN_SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
 RHEL_SSL_CERT_FILE=/etc/pki/tls/certs/ca-bundle.crt
 OPENSUSE_CERT_FILE=/etc/ssl/ca-bundle.pem
+TERMUX_CERT_FILE=/data/data/com.termux/files/usr/etc/tls/cert.pem
 
 if [ ! -f "$SSL_CERT_FILE" ] ; then
   if [ -f "$DEBIAN_SSL_CERT_FILE" ] ; then
@@ -285,6 +286,8 @@ if [ ! -f "$SSL_CERT_FILE" ] ; then
     SSL_CERT_FILE="$RHEL_SSL_CERT_FILE"
   elif [ -f "$OPENSUSE_CERT_FILE" ] ; then
     SSL_CERT_FILE="$OPENSUSE_CERT_FILE"
+  elif [ -f "$TERMUX_CERT_FILE" ] ; then
+    SSL_CERT_FILE="$TERMUX_CERT_FILE"
   fi
 fi
 

--- a/src/execute.c
+++ b/src/execute.c
@@ -142,10 +142,6 @@ static struct cmd_func groupchat_commands[] = {
     { "/unsilence", cmd_unsilence      },
     { "/voice",     cmd_set_voice      },
     { "/whois",     cmd_whois          },
-#ifdef AUDIO
-    { "/mute",      cmd_mute           },
-    { "/sense",     cmd_sense          },
-#endif /* AUDIO */
     { NULL,         NULL               },
 };
 

--- a/src/groupchat_commands.c
+++ b/src/groupchat_commands.c
@@ -141,6 +141,8 @@ void cmd_ignore(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[
     }
 
     line_info_add(self, true, NULL, NULL, SYS_MSG, 1, BLUE, "-!- Ignoring %s", nick);
+
+    group_toggle_peer_ignore(self->num, peer_id, true);
 }
 
 void cmd_kick(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[MAX_STR_SIZE])
@@ -842,6 +844,8 @@ void cmd_unignore(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv
     }
 
     line_info_add(self, true, NULL, NULL, SYS_MSG, 1, BLUE, "-!- You are no longer ignoring %s", nick);
+
+    group_toggle_peer_ignore(self->num, peer_id, false);
 }
 
 void cmd_whois(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[MAX_STR_SIZE])

--- a/src/groupchats.c
+++ b/src/groupchats.c
@@ -117,12 +117,6 @@ static const char *group_cmd_list[] = {
     "/voice",
     "/whisper",
     "/whois",
-#ifdef AUDIO
-    "/lsdev",
-    "/sdev",
-    "/mute",
-    "/sense",
-#endif /* AUDIO */
 };
 
 GroupChat groupchats[MAX_GROUPCHAT_NUM];

--- a/src/groupchats.h
+++ b/src/groupchats.h
@@ -47,6 +47,7 @@ typedef struct GroupPeer {
     uint8_t          public_key[TOX_GROUP_PEER_PUBLIC_KEY_SIZE];
     TOX_USER_STATUS  status;
     Tox_Group_Role   role;
+    bool             is_ignored;
     uint64_t         last_active;
 } GroupPeer;
 
@@ -55,6 +56,9 @@ typedef struct {
     char       **name_list;   /* List of peer names, needed for tab completion */
     uint32_t   num_peers;     /* Number of peers in the chat/name_list array */
     uint32_t   max_idx;       /* Maximum peer list index - 1 */
+
+    uint8_t    **ignored_list; /* List of keys of peers that we're ignoring */
+    uint16_t   num_ignored;
 
     char       group_name[TOX_GROUP_MAX_GROUP_NAME_LENGTH + 1];
     size_t     group_name_length;
@@ -107,5 +111,10 @@ void redraw_groupchat_win(ToxWindow *self);
  * Return NULL if groupnumber is invalid.
  */
 GroupChat *get_groupchat(uint32_t groupnumber);
+
+/**
+ * Toggles the ignore status of the peer associated with `peer_id`.
+ */
+void group_toggle_peer_ignore(uint32_t groupnumber, int peer_id, bool ignore);
 
 #endif /* #define GROUPCHATS_H */


### PR DESCRIPTION
Ignoring a peer now persists if they leave/disconnect and rejoin the group. In addition, ignore status is now displayed in the peer list sidebar as a red # symbol.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/toxic/231)
<!-- Reviewable:end -->
