### PR TITLE
fix: Properly determine the host of a chess game on initialization

### DIFF
--- a/src/chat_commands.c
+++ b/src/chat_commands.c
@@ -272,7 +272,7 @@ void cmd_game_join(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*arg
     uint8_t *data = Friends.list[self->num].game_invite.data;
     size_t length = Friends.list[self->num].game_invite.data_length;
 
-    int ret = game_initialize(self, m, type, id, data, length);
+    int ret = game_initialize(self, m, type, id, data, length, false);
 
     switch (ret) {
         case 0: {

--- a/src/game_base.c
+++ b/src/game_base.c
@@ -203,7 +203,7 @@ static void game_toggle_pause(GameData *game)
     }
 }
 
-static int game_initialize_type(GameData *game, const uint8_t *data, size_t length)
+static int game_initialize_type(GameData *game, const uint8_t *data, size_t length, bool self_host)
 {
     int ret = -3;
 
@@ -219,7 +219,7 @@ static int game_initialize_type(GameData *game, const uint8_t *data, size_t leng
         }
 
         case GT_Chess: {
-            ret = chess_initialize(game, data, length);
+            ret = chess_initialize(game, data, length, self_host);
             break;
         }
 
@@ -237,7 +237,7 @@ static int game_initialize_type(GameData *game, const uint8_t *data, size_t leng
 }
 
 int game_initialize(const ToxWindow *parent, Tox *m, GameType type, uint32_t id, const uint8_t *multiplayer_data,
-                    size_t length)
+                    size_t length, bool self_host)
 {
     int max_x;
     int max_y;
@@ -293,7 +293,7 @@ int game_initialize(const ToxWindow *parent, Tox *m, GameType type, uint32_t id,
         return -4;
     }
 
-    int init_ret = game_initialize_type(game, multiplayer_data, length);
+    int init_ret = game_initialize_type(game, multiplayer_data, length, self_host);
 
     if (init_ret < 0) {
         game_init_abort(parent, self);
@@ -506,7 +506,7 @@ static int game_restart(GameData *game)
 
     game_clear_all_messages(game);
 
-    if (game_initialize_type(game, NULL, 0) == -1) {
+    if (game_initialize_type(game, NULL, 0, false) == -1) {
         return -1;
     }
 

--- a/src/game_base.h
+++ b/src/game_base.h
@@ -214,10 +214,13 @@ void game_set_cb_on_packet(GameData *game, cb_game_on_packet *func, void *cb_dat
  * `type` must be a valid GameType.
  *
  * `id` should be a unique integer to indentify the game instance. If we're being invited to a game
- *   this identifier should be sent via the invite packet.
+ *  this identifier should be sent via the invite packet.
  *
- * if `multiplayer_data` is non-null this indicates that we accepted a game invite from a contact.
- *   The data contains any information we need to initialize the game state.
+ * if `multiplayer_data` is non-null it contains information that we received from the inviter
+ * necessary to initialize the game state.
+ *
+ * if `self_host` is true, the caller is the host of the game. If the game is not initialized from a
+ * friend's chat window this parameter has no effect.
  *
  * Return 0 on success.
  * Return -1 if screen is too small.
@@ -226,7 +229,7 @@ void game_set_cb_on_packet(GameData *game, cb_game_on_packet *func, void *cb_dat
  * Return -4 on other failure.
  */
 int game_initialize(const ToxWindow *self, Tox *m, GameType type, uint32_t id, const uint8_t *multiplayer_data,
-                    size_t length);
+                    size_t length, bool self_host);
 
 /*
  * Sets game window to `shape`.

--- a/src/game_chess.h
+++ b/src/game_chess.h
@@ -28,17 +28,17 @@
 /*
  * Initializes chess game state.
  *
- * If `init_data` is non-null, this indicates that we were invited to the game.
+ * If `self_host` is false, this indicates that we were invited to the game.
  *
- * If we're the inviter, we send an invite packet after initialization. If we're the
- * invitee, we send a handshake response packet to the inviter.
+ * `init_data` of length `length` is the game data sent to us by the inviter
+ * needed to start the game.
  *
  * Return 0 on success.
  * Return -1 if window is too small.
  * Return -2 on network related error.
  * Return -3 on other error.
  */
-int chess_initialize(GameData *game, const uint8_t *init_data, size_t length);
+int chess_initialize(GameData *game, const uint8_t *init_data, size_t length, bool self_host);
 
 #endif // GAME_CHESS
 

--- a/src/global_commands.c
+++ b/src/global_commands.c
@@ -363,7 +363,7 @@ void cmd_game(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[MA
     }
 
     uint32_t id = rand();
-    int ret = game_initialize(self, m, type, id, NULL, 0);
+    int ret = game_initialize(self, m, type, id, NULL, 0, true);
 
     switch (ret) {
         case 0: {


### PR DESCRIPTION
We previously used the length of the invite packet to determine if we were the host of a chess game. This allowed a friend to send an invite packet with a length of zero to trick you into starting a game of chess with yourself as the host. The effect of this was just a broken game in which neither peer could make a move. 

We now determine who the host is independently and in addition do more thorough packet size enforcement
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/toxic/234)
<!-- Reviewable:end -->
