### PR TITLE
feat: add IP address to group whois

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -61,7 +61,8 @@ Run `make doc` in the build directory after editing the asciidoc files to regene
   * `DISABLE_GAMES=1` → Disable support for games
   * `ENABLE_PYTHON=1` → Build toxic with Python scripting support
   * `ENABLE_RELEASE=1` → Build toxic without debug symbols and with full compiler optimizations
-  * `ENABLE_ASAN=1` → Build toxic with LLVM Address Sanitizer enabled
+  * `ENABLE_ASAN=1` → Build toxic with LLVM Address Sanitizer enabled (reduces performance but increases security)
+  * `ENABLE_TOX_EXPERIMENTAL=1` → Build with support for Tox's experimental API functionality
 
 * `DESTDIR=""` Specifies the base install directory for binaries and data files (e.g.: DESTDIR="/tmp/build/pkg")
 

--- a/cfg/checks/check_features.mk
+++ b/cfg/checks/check_features.mk
@@ -28,34 +28,40 @@ ifneq ($(GAMES), disabled)
     -include $(CHECKS_DIR)/games.mk
 endif
 
-# Check if we want build sound notifications support
+# Check if we want to build with sound notifications support
 SND_NOTIFY := $(shell if [ -z "$(DISABLE_SOUND_NOTIFY)" ] || [ "$(DISABLE_SOUND_NOTIFY)" = "0" ] ; then echo enabled ; else echo disabled ; fi)
 ifneq ($(SND_NOTIFY), disabled)
     -include $(CHECKS_DIR)/sound_notifications.mk
 endif
 
-# Check if we want build desktop notifications support
+# Check if we want to build with desktop notifications support
 DESK_NOTIFY := $(shell if [ -z "$(DISABLE_DESKTOP_NOTIFY)" ] || [ "$(DISABLE_DESKTOP_NOTIFY)" = "0" ] ; then echo enabled ; else echo disabled ; fi)
 ifneq ($(DESK_NOTIFY), disabled)
     -include $(CHECKS_DIR)/desktop_notifications.mk
 endif
 
-# Check if we want build QR export support
+# Check if we want to build with QR export support
 QR_CODE := $(shell if [ -z "$(DISABLE_QRCODE)" ] || [ "$(DISABLE_QRCODE)" = "0" ] ; then echo enabled ; else echo disabled ; fi)
 ifneq ($(QR_CODE), disabled)
     -include $(CHECKS_DIR)/qr.mk
 endif
 
-# Check if we want build QR exported as PNG support
+# Check if we want to build with QR exported as PNG support
 QR_PNG := $(shell if [ -z "$(DISABLE_QRPNG)" ] || [ "$(DISABLE_QRPNG)" = "0" ] ; then echo enabled ; else echo disabled ; fi)
 ifneq ($(QR_PNG), disabled)
     -include $(CHECKS_DIR)/qr_png.mk
 endif
 
-# Check if we want build Python scripting support
+# Check if we want to build with Python scripting support
 PYTHON := $(shell if [ -z "$(ENABLE_PYTHON)" ] || [ "$(ENABLE_PYTHON)" = "0" ] ; then echo disabled ; else echo enabled ; fi)
 ifneq ($(PYTHON), disabled)
     -include $(CHECKS_DIR)/python.mk
+endif
+
+# Check if we want to build with tox experimental libaries
+TOX_EXPERIMENTAL := $(shell if [ -z "$(ENABLE_TOX_EXPERIMENTAL)" ] || [ "$(ENABLE_TOX_EXPERIMENTAL)" = "0" ] ; then echo disabled; else echo enabled; fi)
+ifneq ($(TOX_EXPERIMENTAL), disabled)
+    -include $(CHECKS_DIR)/tox_experimental.mk
 endif
 
 # Check if we can build Toxic

--- a/cfg/checks/tox_experimental.mk
+++ b/cfg/checks/tox_experimental.mk
@@ -1,0 +1,3 @@
+# Variables for supporting Tox's experimental API functionality
+TOX_EXPERIMENTAL_CFLAGS = -DTOX_EXPERIMENTAL
+CFLAGS += $(TOX_EXPERIMENTAL_CFLAGS)

--- a/script/build-minimal-static-toxic.sh
+++ b/script/build-minimal-static-toxic.sh
@@ -136,10 +136,10 @@ mkdir -p "$BUILD_DIR"
 cd "$BUILD_DIR"
 
 # The git hash of the c-toxcore version we're using
-TOXCORE_VERSION="172f279dc0647a538b30e62c96bab8bb1b0c8960"
+TOXCORE_VERSION="b2315c50e0838687cd328838f1475be095b358f4"
 
 # The sha256sum of the c-toxcore tarball for TOXCORE_VERSION
-TOXCORE_HASH="9884d4ad9b80917e22495c2ebe7a76c509fb98c61031824562883225e66684ae"
+TOXCORE_HASH="acad3fee6cb88fc2c9b2f17e06cb788467477a7a336475c2fcc8f35e54a3248d"
 
 TOXCORE_FILENAME="c-toxcore-$TOXCORE_VERSION.tar.gz"
 
@@ -237,6 +237,7 @@ CFLAGS="-static" PKG_CONFIG_PATH="$BUILD_DIR/prefix-toxcore/lib64/pkgconfig:$BUI
   ENABLE_RELEASE=1 \
   ENABLE_ASAN=0 \
   DISABLE_GAMES=0 \
+  ENABLE_TOX_EXPERIMENTAL=1 \
   install
 
 

--- a/src/toxic.h
+++ b/src/toxic.h
@@ -44,6 +44,10 @@
 
 #include <tox/tox.h>
 
+#ifdef TOX_EXPERIMENTAL
+#include <tox/tox_private.h>
+#endif
+
 #define UNKNOWN_NAME "Anonymous"
 #define DEFAULT_TOX_NAME "Tox User"   /* should always be the same as toxcore's default name */
 


### PR DESCRIPTION
When you do a `/whois` on a group peer you now see their real IP address listed with the rest of their info. If they aren't accepting direct connections then you will see a placeholder value indicating as much. If you `/whois` yourself, you'll see either your own IP address or a placeholder value, depending on whether or not you're accepting direct connections.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/toxic/238)
<!-- Reviewable:end -->
