### PR TITLE
fix: don't show group quit notifications when disabled in config

### DIFF
--- a/doc/toxic.conf.5
+++ b/doc/toxic.conf.5
@@ -2,12 +2,12 @@
 .\"     Title: toxic.conf
 .\"    Author: [see the "AUTHORS" section]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 2022-06-27
+.\"      Date: 2023-03-04
 .\"    Manual: Toxic Manual
 .\"    Source: toxic __VERSION__
 .\"  Language: English
 .\"
-.TH "TOXIC\&.CONF" "5" "2022\-06\-27" "toxic __VERSION__" "Toxic Manual"
+.TH "TOXIC\&.CONF" "5" "2023\-03\-04" "toxic __VERSION__" "Toxic Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -140,7 +140,7 @@ Enable friend connection change notifications\&. true or false
 .PP
 \fBshow_group_connection_msg\fR
 .RS 4
-Enable group connection change notifications (does not include quit messages)\&. true or false
+Enable group connection change notifications\&. true or false
 .RE
 .PP
 \fBnodelist_update_freq\fR

--- a/doc/toxic.conf.5.asc
+++ b/doc/toxic.conf.5.asc
@@ -88,7 +88,7 @@ OPTIONS
         Enable friend connection change notifications. true or false
 
     *show_group_connection_msg*;;
-        Enable group connection change notifications (does not include quit messages). true or false
+        Enable group connection change notifications. true or false
 
     *nodelist_update_freq*;;
         How often in days to update the DHT nodes list. (integer; 0 to disable)

--- a/misc/toxic.conf.example
+++ b/misc/toxic.conf.example
@@ -56,7 +56,7 @@ ui = {
   // true to show friend connection change messages on the home screen
   show_connection_msg=true;
 
-  // true to show peer connection change messages in groups (setting to false does not include user quit messages)
+  // true to show peer connection change messages in groups
   show_group_connection_msg=true;
 
   // How often in days to update the DHT nodes list. (0 to disable updates)

--- a/src/groupchats.c
+++ b/src/groupchats.c
@@ -1162,9 +1162,9 @@ static void groupchat_onGroupPeerJoin(ToxWindow *self, Tox *m, uint32_t groupnum
             ++chat->max_idx;
         }
 
+        /* ignore join messages when we first connect to the group */
         if (timed_out(chat->time_connected, 60)
-                && user_settings->show_group_connection_msg ==
-                SHOW_GROUP_CONNECTION_MSG_ON) {   /* ignore join messages when we first connect to the group */
+                && user_settings->show_group_connection_msg == SHOW_GROUP_CONNECTION_MSG_ON) {
             line_info_add(self, true, peer->name, NULL, CONNECTION, 0, GREEN, "has joined the room");
 
             write_to_log("has joined the room", peer->name, self->chatwin->log, true);
@@ -1194,7 +1194,8 @@ void groupchat_onGroupPeerExit(ToxWindow *self, Tox *m, uint32_t groupnumber, ui
         return;
     }
 
-    if (exit_type != TOX_GROUP_EXIT_TYPE_SELF_DISCONNECTED) {
+    if (exit_type != TOX_GROUP_EXIT_TYPE_SELF_DISCONNECTED
+            && user_settings->show_group_connection_msg == SHOW_GROUP_CONNECTION_MSG_ON) {
         char log_str[TOX_MAX_NAME_LENGTH + MAX_STR_SIZE];
 
         if (length > 0) {
@@ -1202,7 +1203,7 @@ void groupchat_onGroupPeerExit(ToxWindow *self, Tox *m, uint32_t groupnumber, ui
             snprintf(log_str, sizeof(log_str), "has left the room (%s)", part_message);
             write_to_log(log_str, name, self->chatwin->log, true);
             sound_notify(self, silent, NT_WNDALERT_2, NULL);
-        } else if (user_settings->show_group_connection_msg == SHOW_GROUP_CONNECTION_MSG_ON) {
+        } else {
             const char *exit_string = get_group_exit_string(exit_type);
             line_info_add(self, true, name, NULL, DISCONNECTION, 0, RED, "[%s]", exit_string);
             snprintf(log_str, sizeof(log_str), "[%s]", exit_string);


### PR DESCRIPTION
Currently when your group connection messages are disabled in the config and someone manually leaves the group, you still see a part message. The purpose of this exception was to reduce spam due to poor connections without losing explicit part messages, but I think this can lead to confusion. Now the config option just blocks all group connection messages regardless of type.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/toxic/239)
<!-- Reviewable:end -->
