### PR TITLE
fix: memory leak on groupchat window creation failure

### DIFF
--- a/src/conference.c
+++ b/src/conference.c
@@ -142,15 +142,22 @@ void conference_set_title(ToxWindow *self, uint32_t conferencesnum, const char *
 
 static void kill_conference_window(ToxWindow *self)
 {
+    if (self == NULL) {
+        return;
+    }
+
     ChatContext *ctx = self->chatwin;
 
-    log_disable(ctx->log);
-    line_info_cleanup(ctx->hst);
-    delwin(ctx->linewin);
-    delwin(ctx->history);
-    delwin(ctx->sidebar);
-    free(ctx->log);
-    free(ctx);
+    if (ctx != NULL) {
+        log_disable(ctx->log);
+        line_info_cleanup(ctx->hst);
+        delwin(ctx->linewin);
+        delwin(ctx->history);
+        delwin(ctx->sidebar);
+        free(ctx->log);
+        free(ctx);
+    }
+
     free(self->help);
     kill_notifs(self->active_box);
     del_window(self);

--- a/src/groupchats.c
+++ b/src/groupchats.c
@@ -213,16 +213,24 @@ void groupchat_rejoin(ToxWindow *self, Tox *m)
 
 static void kill_groupchat_window(ToxWindow *self)
 {
+    if (self == NULL) {
+        return;
+    }
+
     ChatContext *ctx = self->chatwin;
 
-    log_disable(ctx->log);
-    line_info_cleanup(ctx->hst);
-    delwin(ctx->linewin);
-    delwin(ctx->history);
-    delwin(ctx->sidebar);
-    free(ctx->log);
-    free(ctx);
+    if (ctx != NULL) {
+        log_disable(ctx->log);
+        line_info_cleanup(ctx->hst);
+        delwin(ctx->linewin);
+        delwin(ctx->history);
+        delwin(ctx->sidebar);
+        free(ctx->log);
+        free(ctx);
+    }
+
     free(self->help);
+    kill_notifs(self->active_box);
     del_window(self);
 }
 
@@ -356,6 +364,8 @@ int init_groupchat_win(Tox *m, uint32_t groupnumber, const char *groupname, size
             return 0;
         }
     }
+
+    kill_groupchat_window(self);
 
     return -1;
 }

--- a/src/line_info.c
+++ b/src/line_info.c
@@ -85,6 +85,10 @@ void line_info_reset_start(ToxWindow *self, struct history *hst)
 
 void line_info_cleanup(struct history *hst)
 {
+    if (hst == NULL) {
+        return;
+    }
+
     struct line_info *tmp1 = hst->line_root;
 
     while (tmp1) {


### PR DESCRIPTION
Also do some safety null checks in group and conferences cleanup functions

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/toxic/246)
<!-- Reviewable:end -->
