### PR TITLE
fix: incorrect buffer size passed to function

### DIFF
--- a/src/misc_tools.c
+++ b/src/misc_tools.c
@@ -267,7 +267,6 @@ int wstring_is_empty(const wchar_t *string)
     return string[0] == L'\0';
 }
 
-/* convert a multibyte string to a wide character string and puts in buf. */
 int mbs_to_wcs_buf(wchar_t *buf, const char *string, size_t n)
 {
     size_t len = mbstowcs(NULL, string, 0) + 1;
@@ -283,7 +282,6 @@ int mbs_to_wcs_buf(wchar_t *buf, const char *string, size_t n)
     return len;
 }
 
-/* converts wide character string into a multibyte string and puts in buf. */
 int wcs_to_mbs_buf(char *buf, const wchar_t *string, size_t n)
 {
     size_t len = wcstombs(NULL, string, 0) + 1;

--- a/src/misc_tools.h
+++ b/src/misc_tools.h
@@ -115,11 +115,23 @@ int wstring_is_empty(const wchar_t *string);
 /* converts a multibyte string to a wide character string (must provide buffer) */
 int char_to_wcs_buf(wchar_t *buf, const char *string, size_t n);
 
-/* converts wide character string into a multibyte string and puts in buf. */
-int wcs_to_mbs_buf(char *buf, const wchar_t *string, size_t n);
-
-/* converts a multibyte string to a wide character string and puts in buf) */
+/* Converts a multibyte string to a wide character string and puts in `buf`.
+ *
+ * `buf` must have room for at least `n` wide characters (wchar_t's).
+ *
+ * Return number of wide characters written on success.
+ * Return -1 on failure.
+ */
 int mbs_to_wcs_buf(wchar_t *buf, const char *string, size_t n);
+
+/* Converts a wide character string into a multibyte string and puts in `buf`.
+ *
+ * `buf` must have room for at least `n` bytes.
+ *
+ * Return number of bytes written on success.
+ * Return -1 on failure.
+ */
+int wcs_to_mbs_buf(char *buf, const wchar_t *string, size_t n);
 
 /* Returns 1 if connection has timed out, 0 otherwise */
 int timed_out(time_t timestamp, time_t timeout);


### PR DESCRIPTION
The function expects a widechar count rather than a byte count.
This is a serious error that would lead to a buffer overflow
if not for the fact that the input char buffer passed to the
function uses the same size constant as the output wchar buffer


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/toxic/251)
<!-- Reviewable:end -->
