### PR TITLE
cleanup: remove message about name lookup server list being empty from prompt

### DIFF
--- a/src/toxic.c
+++ b/src/toxic.c
@@ -1627,7 +1627,7 @@ int main(int argc, char **argv)
     } else if (nameserver_ret == -2) {
         queue_init_message("Name lookup server list could not be found.");
     } else if (nameserver_ret == -3) {
-        queue_init_message("Name lookup server list does not contain any valid entries.");
+        fprintf(stderr, "Name lookup server list does not contain any valid entries\n");
     }
 
 #ifdef X11


### PR DESCRIPTION
This message sounds like an error but it's not. The name lookup service hasn't been in use for years and isn't something users need to worry about.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/toxic/255)
<!-- Reviewable:end -->
