### PR TITLE
fix: error reporting for conference audio enabling and disabling

### DIFF
--- a/src/conference.c
+++ b/src/conference.c
@@ -1348,7 +1348,13 @@ bool enable_conference_audio(ToxWindow *self, Tox *tox, uint32_t conferencenum)
         }
     }
 
-    bool success = init_conference_audio_input(tox, conferencenum);
+    const ConferenceChat *chat = &conferences[conferencenum];
+
+    if (chat->audio_enabled) {
+        return true;
+    }
+
+    const bool success = init_conference_audio_input(tox, conferencenum);
 
     if (success) {
         self->is_call = true;
@@ -1368,9 +1374,11 @@ bool disable_conference_audio(ToxWindow *self, Tox *tox, uint32_t conferencenum)
     if (chat->audio_enabled) {
         close_device(input, chat->audio_in_idx);
         chat->audio_enabled = false;
+    } else {
+        return true;
     }
 
-    bool success = toxav_groupchat_disable_av(tox, conferencenum) == 0;
+    const bool success = toxav_groupchat_disable_av(tox, conferencenum) == 0;
 
     if (success) {
         self->is_call = false;

--- a/src/conference.h
+++ b/src/conference.h
@@ -102,9 +102,19 @@ int conference_enable_logging(ToxWindow *self, Tox *m, uint32_t conferencenum, s
 uint32_t get_name_list_entries_by_prefix(uint32_t conferencenum, const char *prefix, NameListEntry **entries,
         uint32_t maxpeers);
 
-bool init_conference_audio_input(Tox *tox, uint32_t conferencenum);
+/* Enable audio in a conference.
+ *
+ * Return true on success or if audio is already enabled.
+ */
 bool enable_conference_audio(ToxWindow *self, Tox *tox, uint32_t conferencenum);
+
+/* Disable audio in a conference.
+ *
+ * Return true on success or if audio is already disabled.
+ */
 bool disable_conference_audio(ToxWindow *self, Tox *tox, uint32_t conferencenum);
+
+bool init_conference_audio_input(Tox *tox, uint32_t conferencenum);
 bool toggle_conference_push_to_talk(uint32_t conferencenum, bool enabled);
 void audio_conference_callback(void *tox, uint32_t conferencenum, uint32_t peernum,
                                const int16_t *pcm, unsigned int samples, uint8_t channels, uint32_t


### PR DESCRIPTION
We no longer report an error if we try to enable audio when audio is already enabled, or vice versa.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/toxic/256)
<!-- Reviewable:end -->
