### PR TITLE
cleanup: Remove unnecessary assert and includes

### DIFF
--- a/src/audio_call.c
+++ b/src/audio_call.c
@@ -39,7 +39,6 @@
 #include "video_call.h"
 #endif /* VIDEO */
 
-#include <assert.h>
 #include <curses.h>
 #include <pthread.h>
 #include <stdbool.h>

--- a/src/audio_device.c
+++ b/src/audio_device.c
@@ -33,7 +33,6 @@
 #include <AL/alext.h>
 #endif /* ALC_ALL_DEVICES_SPECIFIER */
 
-#include <assert.h>
 #include <math.h>
 #include <pthread.h>
 #include <stdbool.h>

--- a/src/chat.c
+++ b/src/chat.c
@@ -24,7 +24,6 @@
 #define _GNU_SOURCE    /* needed for wcswidth() */
 #endif
 
-#include <assert.h>
 #include <limits.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/conference.c
+++ b/src/conference.c
@@ -24,7 +24,6 @@
 #define _GNU_SOURCE    /* needed for strcasestr() and wcswidth() */
 #endif
 
-#include <assert.h>
 #include <inttypes.h>
 #include <math.h>
 #include <stdlib.h>

--- a/src/execute.c
+++ b/src/execute.c
@@ -20,7 +20,6 @@
  *
  */
 
-#include <assert.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/src/friendlist.c
+++ b/src/friendlist.c
@@ -21,7 +21,6 @@
  */
 
 #include <arpa/inet.h>
-#include <assert.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/game_base.c
+++ b/src/game_base.c
@@ -20,7 +20,6 @@
  *
  */
 
-#include <assert.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -923,8 +922,6 @@ static ToxWindow *game_new_window(Tox *m, GameType type, uint32_t friendnumber)
         snprintf(buf, sizeof(buf), "%s (%s)", window_name, nick);
 
         const size_t name_size = sizeof(ret->name);
-
-        assert(name_size != 0 && name_size <= sizeof(buf));
 
         buf[name_size - 1] = '\0';
 

--- a/src/groupchats.c
+++ b/src/groupchats.c
@@ -26,7 +26,6 @@
 
 #include <stdlib.h>
 #include <string.h>
-#include <assert.h>
 #include <time.h>
 #include <wchar.h>
 #include <unistd.h>

--- a/src/notify.c
+++ b/src/notify.c
@@ -20,7 +20,6 @@
  *
  */
 
-#include <assert.h>
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdio.h>

--- a/src/osx_video.m
+++ b/src/osx_video.m
@@ -36,7 +36,6 @@
 #include <pthread.h>
 #include <unistd.h>
 #include <stdlib.h>
-#include <assert.h>
 
 /*
  * Helper video format functions

--- a/src/video_call.c
+++ b/src/video_call.c
@@ -30,7 +30,6 @@
 #include "video_device.h"
 #include "windows.h"
 
-#include <assert.h>
 #include <curses.h>
 #include <pthread.h>
 #include <stdbool.h>


### PR DESCRIPTION
This assert can give odd compile errors and is unnecessary. We can easily prove that sizeof(ret->name) is <= sizeof(buf) as sizeof(buf) includes sizeof(ret->name)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/toxic/259)
<!-- Reviewable:end -->
