### PR TITLE
fix: possible data race

### DIFF
--- a/src/game_base.c
+++ b/src/game_base.c
@@ -307,7 +307,7 @@ int game_initialize(const ToxWindow *parent, Tox *m, GameType type, uint32_t id,
         return -4;
     }
 
-    int init_ret = game_initialize_type(game, multiplayer_data, length, self_host);
+    const int init_ret = game_initialize_type(game, multiplayer_data, length, self_host);
 
     if (init_ret < 0) {
         game_init_abort(parent, self);
@@ -785,7 +785,9 @@ bool game_onKey(ToxWindow *self, Tox *m, wint_t key, bool is_printable)
     GameData *game = self->game;
 
     if (key == KEY_F(9)) {
+        pthread_mutex_lock(&Winthread.lock);
         game_kill(self);
+        pthread_mutex_unlock(&Winthread.lock);
         return true;
     }
 

--- a/src/windows.c
+++ b/src/windows.c
@@ -1020,7 +1020,7 @@ void draw_active_window(Tox *m)
             set_next_window(ch);
         }
 
-        a->onKey(a, m, ch, false);
+        a->onKey(a, m, ch, false);  // we lock only when necessary in the onKey callback
 
         return;
     }


### PR DESCRIPTION
Exiting a game will touch the global windows array and send a packet in the case of multiplayer games, both of which need to be protected by a mutex

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/toxic/261)
<!-- Reviewable:end -->
