### PR TITLE
feat: add a command that lets you change a tab name's colour

### DIFF
--- a/src/chat.c
+++ b/src/chat.c
@@ -73,6 +73,7 @@ static const char *chat_cmd_list[] = {
     "/cjoin",
     "/clear",
     "/close",
+    "/colour",
     "/connect",
     "/exit",
     "/gaccept",

--- a/src/conference.c
+++ b/src/conference.c
@@ -81,6 +81,7 @@ static const char *conference_cmd_list[] = {
     "/avatar",
     "/clear",
     "/close",
+    "/colour",
     "/connect",
     "/decline",
     "/exit",

--- a/src/execute.c
+++ b/src/execute.c
@@ -45,6 +45,7 @@ static struct cmd_func global_commands[] = {
     { "/add",       cmd_add           },
     { "/avatar",    cmd_avatar        },
     { "/clear",     cmd_clear         },
+    { "/colour",    cmd_colour        },
     { "/connect",   cmd_connect       },
     { "/decline",   cmd_decline       },
     { "/exit",      cmd_quit          },

--- a/src/global_commands.c
+++ b/src/global_commands.c
@@ -252,6 +252,39 @@ void cmd_clear(WINDOW *window, ToxWindow *self, Tox *tox, int argc, char (*argv)
     force_refresh(window);
 }
 
+void cmd_colour(WINDOW *window, ToxWindow *self, Tox *tox, int argc, char (*argv)[MAX_STR_SIZE])
+{
+    UNUSED_VAR(window);
+    UNUSED_VAR(tox);
+
+    if (argc != 1) {
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0,
+                      "Change the name of the focused window with /colour [white|black|yellow|red|green|cyan|purple]");
+        return;
+    }
+
+    const char *colour = argv[1];
+
+    if (strcasecmp(colour, "white") == 0) {
+        self->colour = WHITE_BAR_FG;
+    } else if (strcasecmp(colour, "red") == 0) {
+        self->colour = RED_BAR_FG;
+    } else if (strcasecmp(colour, "green") == 0) {
+        self->colour = GREEN_BAR_FG;
+    } else if (strcasecmp(colour, "yellow") == 0) {
+        self->colour = YELLOW_BAR_FG;
+    } else if (strcasecmp(colour, "cyan") == 0) {
+        self->colour = CYAN_BAR_FG;
+    } else if (strcasecmp(colour, "purple") == 0) {
+        self->colour = PURPLE_BAR_FG;
+    } else if (strcasecmp(colour, "black") == 0) {
+        self->colour = BLACK_BAR_FG;
+    } else {
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Invalid colour");
+        return;
+    }
+}
+
 void cmd_connect(WINDOW *window, ToxWindow *self, Tox *tox, int argc, char (*argv)[MAX_STR_SIZE])
 {
     UNUSED_VAR(window);

--- a/src/global_commands.h
+++ b/src/global_commands.h
@@ -30,6 +30,7 @@ void cmd_accept(WINDOW *, ToxWindow *, Tox *, int argc, char (*argv)[MAX_STR_SIZ
 void cmd_add(WINDOW *, ToxWindow *, Tox *, int argc, char (*argv)[MAX_STR_SIZE]);
 void cmd_avatar(WINDOW *window, ToxWindow *self, Tox *tox, int argc, char (*argv)[MAX_STR_SIZE]);
 void cmd_clear(WINDOW *, ToxWindow *, Tox *, int argc, char (*argv)[MAX_STR_SIZE]);
+void cmd_colour(WINDOW *window, ToxWindow *self, Tox *tox, int argc, char (*argv)[MAX_STR_SIZE]);
 void cmd_conference(WINDOW *, ToxWindow *, Tox *, int argc, char (*argv)[MAX_STR_SIZE]);
 void cmd_connect(WINDOW *, ToxWindow *, Tox *, int argc, char (*argv)[MAX_STR_SIZE]);
 void cmd_decline(WINDOW *window, ToxWindow *self, Tox *tox, int argc, char (*argv)[MAX_STR_SIZE]);

--- a/src/groupchats.c
+++ b/src/groupchats.c
@@ -77,6 +77,7 @@ static const char *group_cmd_list[] = {
     "/chatid",
     "/clear",
     "/close",
+    "/colour",
     "/conference",
     "/connect",
     "/disconnect",

--- a/src/help.c
+++ b/src/help.c
@@ -177,6 +177,7 @@ static void help_draw_global(ToxWindow *self)
     wprintw(win, "  /add <addr> <msg>          : Add contact with optional message\n");
     wprintw(win, "  /accept <id>               : Accept friend request\n");
     wprintw(win, "  /avatar <path>             : Set an avatar (leave path empty to unset)\n");
+    wprintw(win, "  /colour <c>                : Change the colour of the focused window's name\n");
     wprintw(win, "  /conference <type>         : Create a conference where type: text | audio\n");
     wprintw(win, "  /connect <ip> <port> <key> : Manually connect to a DHT node\n");
     wprintw(win, "  /decline <id>              : Decline friend request\n");
@@ -449,7 +450,7 @@ void help_onKey(ToxWindow *self, wint_t key)
             break;
 
         case L'g':
-            height = 24;
+            height = 25;
 #ifdef VIDEO
             height += 8;
 #elif AUDIO

--- a/src/prompt.c
+++ b/src/prompt.c
@@ -56,6 +56,7 @@ static const char *glob_cmd_list[] = {
     "/add",
     "/avatar",
     "/clear",
+    "/colour",
     "/connect",
     "/decline",
     "/exit",

--- a/src/toxic.c
+++ b/src/toxic.c
@@ -442,6 +442,13 @@ static void init_term(void)
         init_pair(STATUS_ONLINE, COLOR_GREEN, bar_bg_color);
         init_pair(STATUS_AWAY, COLOR_YELLOW, bar_bg_color);
         init_pair(STATUS_BUSY, COLOR_RED, bar_bg_color);
+        init_pair(WHITE_BAR_FG, COLOR_WHITE, bar_bg_color);
+        init_pair(RED_BAR_FG, COLOR_RED, bar_bg_color);
+        init_pair(GREEN_BAR_FG, COLOR_GREEN, bar_bg_color);
+        init_pair(CYAN_BAR_FG, COLOR_CYAN, bar_bg_color);
+        init_pair(PURPLE_BAR_FG, COLOR_MAGENTA, bar_bg_color);
+        init_pair(YELLOW_BAR_FG, COLOR_YELLOW, bar_bg_color);
+        init_pair(BLACK_BAR_FG, COLOR_BLACK, bar_bg_color);
     }
 
     refresh();

--- a/src/windows.c
+++ b/src/windows.c
@@ -581,6 +581,7 @@ int add_window(Tox *tox, ToxWindow *w)
 
         w->index = i;
         w->window = newwin(LINES, COLS, 0, 0);
+        w->colour = BAR_TEXT;
 
         if (w->window == NULL) {
             return -1;
@@ -816,8 +817,18 @@ static void draw_window_tab(WINDOW *win, ToxWindow *toxwin, bool active_window)
         }
     }
 
-    if (active_window || (type == WINDOW_TYPE_PROMPT || type == WINDOW_TYPE_FRIEND_LIST)) {
+    if (type == WINDOW_TYPE_PROMPT || type == WINDOW_TYPE_FRIEND_LIST) {
+        if (!has_alert) {
+            wattron(win, COLOR_PAIR(toxwin->colour));
+            wprintw(win, "%s", toxwin->name);
+            wattroff(win, COLOR_PAIR(toxwin->colour));
+        } else {
+            wprintw(win, "%s", toxwin->name);
+        }
+    } else if (active_window) {
+        wattron(win, COLOR_PAIR(toxwin->colour));
         wprintw(win, "%s", toxwin->name);
+        wattroff(win, COLOR_PAIR(toxwin->colour));
     } else {
         if (pending_messages > 0) {
             wprintw(win, "%u", pending_messages);

--- a/src/windows.h
+++ b/src/windows.h
@@ -73,6 +73,13 @@ typedef enum {
     STATUS_AWAY,
     BAR_NOTIFY,
     BAR_SOLID,
+    WHITE_BAR_FG,
+    RED_BAR_FG,
+    GREEN_BAR_FG,
+    CYAN_BAR_FG,
+    PURPLE_BAR_FG,
+    YELLOW_BAR_FG,
+    BLACK_BAR_FG,
 } C_COLOURS;
 
 /* tab alert types: lower types take priority (this relies on the order of C_COLOURS) */
@@ -232,6 +239,7 @@ struct ToxWindow {
     int active_box; /* For box notify */
 
     char name[TOXIC_MAX_NAME_LENGTH + 1];
+    int colour;  /* The ncurses colour pair of the window name */
     uint32_t num;    /* corresponds to friendnumber in chat windows */
     uint8_t index; /* This window's index in the windows array */
     bool scroll_pause; /* true if this window is not scrolled to the bottom */


### PR DESCRIPTION
In the future we hope to be able to make these permanently set via the toxic config file

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/toxic/275)
<!-- Reviewable:end -->
