### PR TITLE
feat: add support for friend config settings

### DIFF
--- a/doc/toxic.conf.5
+++ b/doc/toxic.conf.5
@@ -2,12 +2,12 @@
 .\"     Title: toxic.conf
 .\"    Author: [see the "AUTHORS" section]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 2023-03-04
+.\"      Date: 2023-12-19
 .\"    Manual: Toxic Manual
 .\"    Source: toxic __VERSION__
 .\"  Language: English
 .\"
-.TH "TOXIC\&.CONF" "5" "2023\-03\-04" "toxic __VERSION__" "Toxic Manual"
+.TH "TOXIC\&.CONF" "5" "2023\-12\-19" "toxic __VERSION__" "Toxic Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -295,6 +295,16 @@ Default path for chatlogs\&. String value\&. Absolute path for chatlog files\&.
 \fBpassword_eval\fR
 .RS 4
 Replace password prompt by running this command and using its output as the password\&.
+.RE
+.RE
+.PP
+\fBfriends\fR
+.RS 4
+Friend config settings
+.PP
+\fBtab_name_colour\fR
+.RS 4
+The colour of the friend\(cqs tab window name\&. Valid colours are: white, red, green, cyan, purple, yellow, black\&.
 .RE
 .RE
 .PP

--- a/doc/toxic.conf.5.asc
+++ b/doc/toxic.conf.5.asc
@@ -186,6 +186,12 @@ OPTIONS
         Replace password prompt by running this command and using its output as
 	the password.
 
+*friends*::
+    Friend config settings
+
+    *tab_name_colour*;;
+        The colour of the friend's tab window name. Valid colours are: white, red, green, cyan, purple, yellow, black.
+
 *sounds*::
     Configuration related to notification sounds.
     Special value "silent" can be used to disable a specific notification. +

--- a/misc/toxic.conf.example
+++ b/misc/toxic.conf.example
@@ -130,6 +130,20 @@ tox = {
   // chatlogs_path="/home/USERNAME/toxic_chatlogs/";
 };
 
+// Friend config settings. Public keys are used as friend identifiers
+// and must begin with the prefix "pk_".
+friends = {
+  pk_PUBLIC_KEY_1 = {
+    // The colour of the friend's window tab name.
+    // Valid colours are: white, red, green, cyan, purple, yellow, black.
+    tab_name_colour="white";
+  };
+
+  pk_PUBLIC_KEY_2 = {
+    tab_name_colour="white";
+  };
+};
+
 // To disable a sound set the path to "silent"
 sounds = {
   error="__DATADIR__/sounds/ToxicError.wav";

--- a/src/chat.c
+++ b/src/chat.c
@@ -1598,6 +1598,10 @@ static void chat_onInit(ToxWindow *self, Tox *tox)
 
     line_info_init(ctx->hst);
 
+    const int tab_name_colour = friend_config_get_tab_name_colour(self->num);
+
+    self->colour = tab_name_colour > 0 ? tab_name_colour : WHITE_BAR_FG;
+
     chat_init_log(self, tox, nick);
 
     execute(ctx->history, self, tox, "/log", GLOBAL_COMMAND_MODE);  // Print log status to screen

--- a/src/friendlist.h
+++ b/src/friendlist.h
@@ -63,6 +63,14 @@ struct GameInvite {
 
 #endif // GAMES
 
+typedef enum DefaultFriendSettings {
+    DefaultFriendSettingsTabNameColour = WHITE_BAR_FG,
+} DefaultFriendSettings;
+
+typedef struct FriendSettings {
+    int tab_name_colour;
+} FriendSettings;
+
 typedef struct {
     char name[TOXIC_MAX_NAME_LENGTH + 1];
     uint16_t namelength;
@@ -90,6 +98,8 @@ typedef struct {
     struct FileTransfer file_receiver[MAX_FILES];
     struct FileTransfer file_sender[MAX_FILES];
     PendingFileTransfer file_send_queue[MAX_FILES];
+
+    FriendSettings settings;
 } ToxicFriend;
 
 typedef struct {
@@ -141,5 +151,17 @@ void friend_set_auto_file_accept(uint32_t friendnumber, bool auto_accept);
  * Return true if auto-accepting file transfers is enabled for this friend.
  */
 bool friend_get_auto_accept_files(uint32_t friendnumber);
+
+/*
+ * Sets the tab name colour config option for the friend associated with `public_key` to `colour`.
+ *
+ * Return true on success.
+ */
+bool friend_config_set_tab_name_colour(const char *public_key, const char *colour);
+
+/* Returns a friend's tab name colour.
+ * Returns -1 on error.
+ */
+int friend_config_get_tab_name_colour(uint32_t friendnumber);
 
 #endif /* end of include guard: FRIENDLIST_H */

--- a/src/global_commands.c
+++ b/src/global_commands.c
@@ -265,24 +265,14 @@ void cmd_colour(WINDOW *window, ToxWindow *self, Tox *tox, int argc, char (*argv
 
     const char *colour = argv[1];
 
-    if (strcasecmp(colour, "white") == 0) {
-        self->colour = WHITE_BAR_FG;
-    } else if (strcasecmp(colour, "red") == 0) {
-        self->colour = RED_BAR_FG;
-    } else if (strcasecmp(colour, "green") == 0) {
-        self->colour = GREEN_BAR_FG;
-    } else if (strcasecmp(colour, "yellow") == 0) {
-        self->colour = YELLOW_BAR_FG;
-    } else if (strcasecmp(colour, "cyan") == 0) {
-        self->colour = CYAN_BAR_FG;
-    } else if (strcasecmp(colour, "purple") == 0) {
-        self->colour = PURPLE_BAR_FG;
-    } else if (strcasecmp(colour, "black") == 0) {
-        self->colour = BLACK_BAR_FG;
-    } else {
+    const int colour_val = colour_string_to_int(colour);
+
+    if (colour_val < 0) {
         line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Invalid colour");
         return;
     }
+
+    self->colour = colour_val;
 }
 
 void cmd_connect(WINDOW *window, ToxWindow *self, Tox *tox, int argc, char (*argv)[MAX_STR_SIZE])

--- a/src/misc_tools.c
+++ b/src/misc_tools.c
@@ -751,3 +751,36 @@ unsigned int rand_not_secure(void)
 
     return n;
 }
+
+int colour_string_to_int(const char *colour)
+{
+    if (strcasecmp(colour, "white") == 0) {
+        return WHITE_BAR_FG;
+    }
+
+    if (strcasecmp(colour, "red") == 0) {
+        return RED_BAR_FG;
+    }
+
+    if (strcasecmp(colour, "green") == 0) {
+        return GREEN_BAR_FG;
+    }
+
+    if (strcasecmp(colour, "yellow") == 0) {
+        return YELLOW_BAR_FG;
+    }
+
+    if (strcasecmp(colour, "cyan") == 0) {
+        return CYAN_BAR_FG;
+    }
+
+    if (strcasecmp(colour, "purple") == 0) {
+        return PURPLE_BAR_FG;
+    }
+
+    if (strcasecmp(colour, "black") == 0) {
+        return BLACK_BAR_FG;
+    }
+
+    return -1;
+}

--- a/src/misc_tools.h
+++ b/src/misc_tools.h
@@ -250,4 +250,14 @@ unsigned int rand_range_not_secure(unsigned int upper_bound);
  */
 unsigned int rand_not_secure(void);
 
+/*
+ * Returns an integer associated with an ncurses foreground colour, per the C_COLOURS enum
+ * in windows.h.
+ *
+ * Valid colour strings are: white, red, green, cyan, purple, yellow, black.
+ *
+ * Returns -1 if colour is invalid.
+ */
+int colour_string_to_int(const char *colour);
+
 #endif /* MISC_TOOLS_H */

--- a/src/settings.h
+++ b/src/settings.h
@@ -141,6 +141,7 @@ enum settings_values {
 #define LOG_TIMESTAMP_DEFAULT  "%Y/%m/%d [%H:%M:%S]"
 #define MPLEX_AWAY_NOTE "Away from keyboard, be back soon!"
 
-int settings_load(struct user_settings *s, const char *patharg);
+int settings_load_main(struct user_settings *s, const char *patharg);
+int settings_load_friends(const char *patharg);
 
 #endif /* SETTINGS_H */

--- a/src/toxic.c
+++ b/src/toxic.c
@@ -1629,7 +1629,6 @@ int main(int argc, char **argv)
         first_time_encrypt("Encrypt existing data file? Y/n (q to quit)");
     }
 
-
     /* init user_settings struct and load settings from conf file */
     user_settings = calloc(1, sizeof(struct user_settings));
 
@@ -1637,9 +1636,9 @@ int main(int argc, char **argv)
         exit_toxic_err("failed in main", FATALERR_MEMORY);
     }
 
-    const char *p = arg_opts.config_path[0] ? arg_opts.config_path : NULL;
+    const char *config_path = arg_opts.config_path[0] ? arg_opts.config_path : NULL;
 
-    if (settings_load(user_settings, p) == -1) {
+    if (settings_load_main(user_settings, config_path) == -1) {
         queue_init_message("Failed to load user settings");
     }
 
@@ -1676,6 +1675,12 @@ int main(int argc, char **argv)
 
     if (arg_opts.encrypt_data && !datafile_exists) {
         arg_opts.encrypt_data = 0;
+    }
+
+    const int fs_ret = settings_load_friends(config_path);
+
+    if (fs_ret != 0) {
+        queue_init_message("Failed to load friend config settings: error %d", fs_ret);
     }
 
     init_term();


### PR DESCRIPTION
Currently we only have one setting, but this can easily be expanded for a number of things such as auto-accepting file transfers, auto-logging, custom nicknames, message notifications etc.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/toxic/277)
<!-- Reviewable:end -->
