### PR TITLE
feat: add support for groupchat config settings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ CFG_DIR = $(BASE_DIR)/cfg
 
 LIBS = toxcore ncursesw libconfig libcurl
 
-CFLAGS ?= -std=c99 -pthread -Wall -Wpedantic -Wunused -fstack-protector-all -Wvla -Wno-missing-braces
+CFLAGS ?= -std=c11 -pthread -Wall -Wpedantic -Wunused -fstack-protector-all -Wvla -Wno-missing-braces
 CFLAGS += '-DTOXICVER="$(VERSION)"' -DHAVE_WIDECHAR -D_XOPEN_SOURCE_EXTENDED -D_FILE_OFFSET_BITS=64
 CFLAGS += '-DPACKAGE_DATADIR="$(abspath $(DATADIR))"'
 CFLAGS += ${USER_CFLAGS}

--- a/doc/toxic.conf.5
+++ b/doc/toxic.conf.5
@@ -2,12 +2,12 @@
 .\"     Title: toxic.conf
 .\"    Author: [see the "AUTHORS" section]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 2023-12-19
+.\"      Date: 2024-01-17
 .\"    Manual: Toxic Manual
 .\"    Source: toxic __VERSION__
 .\"  Language: English
 .\"
-.TH "TOXIC\&.CONF" "5" "2023\-12\-19" "toxic __VERSION__" "Toxic Manual"
+.TH "TOXIC\&.CONF" "5" "2024\-01\-17" "toxic __VERSION__" "Toxic Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -305,6 +305,16 @@ Friend config settings
 \fBtab_name_colour\fR
 .RS 4
 The colour of the friend\(cqs tab window name\&. Valid colours are: white, red, green, cyan, purple, yellow, black\&.
+.RE
+.RE
+.PP
+\fBgroupchats\fR
+.RS 4
+Groupchat config settings
+.PP
+\fBtab_name_colour\fR
+.RS 4
+The colour of the group\(cqs tab window name\&. Valid colours are: white, red, green, cyan, purple, yellow, black\&.
 .RE
 .RE
 .PP

--- a/doc/toxic.conf.5.asc
+++ b/doc/toxic.conf.5.asc
@@ -187,10 +187,16 @@ OPTIONS
 	the password.
 
 *friends*::
-    Friend config settings
+    Friend-specific config settings
 
     *tab_name_colour*;;
         The colour of the friend's tab window name. Valid colours are: white, red, green, cyan, purple, yellow, black.
+
+*groupchats*::
+    Groupchat-specific config settings
+
+    *tab_name_colour*;;
+        The colour of the group's tab window name. Valid colours are: white, red, green, cyan, purple, yellow, black.
 
 *sounds*::
     Configuration related to notification sounds.

--- a/misc/toxic.conf.example
+++ b/misc/toxic.conf.example
@@ -130,7 +130,7 @@ tox = {
   // chatlogs_path="/home/USERNAME/toxic_chatlogs/";
 };
 
-// Friend config settings. Public keys are used as friend identifiers
+// Friend-specific config settings. Public keys are used as friend identifiers
 // and must begin with the prefix "pk_".
 friends = {
   pk_PUBLIC_KEY_1 = {
@@ -143,6 +143,20 @@ friends = {
     tab_name_colour="white";
   };
 };
+
+// groupchat-specific config settings. Public keys (chat ID's) are used as
+// group identifiers and must begin with the prefix "pk_".
+groupchats = {
+  pk_PUBLIC_KEY_1 = {
+    // The colour of the group's window tab name.
+    // Valid colours are: white, red, green, cyan, purple, yellow, black.
+    tab_name_colour="white";
+  };
+
+  pk_PUBLIC_KEY_2 = {
+    tab_name_colour="white";
+  };
+}
 
 // To disable a sound set the path to "silent"
 sounds = {

--- a/src/chat.c
+++ b/src/chat.c
@@ -1599,7 +1599,6 @@ static void chat_onInit(ToxWindow *self, Tox *tox)
     line_info_init(ctx->hst);
 
     const int tab_name_colour = friend_config_get_tab_name_colour(self->num);
-
     self->colour = tab_name_colour > 0 ? tab_name_colour : WHITE_BAR_FG;
 
     chat_init_log(self, tox, nick);

--- a/src/friendlist.c
+++ b/src/friendlist.c
@@ -1459,6 +1459,10 @@ static FriendSettings *get_friend_settings_by_key(const char *public_key)
     for (size_t i = 0; i < Friends.max_idx; ++i) {
         ToxicFriend *friend = &Friends.list[i];
 
+        if (!friend->active) {
+            continue;
+        }
+
         if (memcmp(pk_bin, friend->pub_key, sizeof(friend->pub_key)) == 0) {
             return &friend->settings;
         }

--- a/src/friendlist.h
+++ b/src/friendlist.h
@@ -159,7 +159,8 @@ bool friend_get_auto_accept_files(uint32_t friendnumber);
  */
 bool friend_config_set_tab_name_colour(const char *public_key, const char *colour);
 
-/* Returns a friend's tab name colour.
+/*
+ * Returns a friend's tab name colour.
  * Returns -1 on error.
  */
 int friend_config_get_tab_name_colour(uint32_t friendnumber);

--- a/src/groupchats.h
+++ b/src/groupchats.h
@@ -23,6 +23,8 @@
 #ifndef GROUPCHATS_H
 #define GROUPCHATS_H
 
+#include <assert.h>
+
 #include "toxic.h"
 #include "windows.h"
 
@@ -31,6 +33,8 @@
 #endif
 
 #define MAX_GROUPCHAT_NUM (MAX_WINDOWS_NUM - 2)
+
+static_assert(TOX_GROUP_CHAT_ID_SIZE == TOX_PUBLIC_KEY_SIZE, "TOX_GROUP_CHAT_ID_SIZE != TOX_PUBLIC_KEY_SIZE");
 
 typedef enum Group_Join_Type {
     Group_Join_Type_Create,
@@ -52,6 +56,7 @@ typedef struct GroupPeer {
 } GroupPeer;
 
 typedef struct {
+    char       chat_id[TOX_GROUP_CHAT_ID_SIZE];
     GroupPeer  *peer_list;
     char       **name_list;   /* List of peer names, needed for tab completion */
     uint32_t   num_peers;     /* Number of peers in the chat/name_list array */
@@ -116,5 +121,14 @@ GroupChat *get_groupchat(uint32_t groupnumber);
  * Toggles the ignore status of the peer associated with `peer_id`.
  */
 void group_toggle_peer_ignore(uint32_t groupnumber, int peer_id, bool ignore);
+
+/*
+ * Sets the tab name colour config option for the groupchat associated with `public_key` to `colour`.
+ *
+ * `public_key` should be a string representing the group's public chat ID.
+ *
+ * Return true on success.
+ */
+bool groupchat_config_set_tab_name_colour(const char *public_key, const char *colour);
 
 #endif /* #define GROUPCHATS_H */

--- a/src/settings.h
+++ b/src/settings.h
@@ -141,7 +141,35 @@ enum settings_values {
 #define LOG_TIMESTAMP_DEFAULT  "%Y/%m/%d [%H:%M:%S]"
 #define MPLEX_AWAY_NOTE "Away from keyboard, be back soon!"
 
+/*
+ * Loads general toxic settings from the toxic config file pointed to by `patharg'.
+ *
+ * Return 0 on success.
+ * Return -1 if we fail to open the file path.
+ * Return -2 if libconfig fails to read the config file.
+ */
 int settings_load_main(struct user_settings *s, const char *patharg);
+
+/*
+ * Loads friend config settings from the toxic config file pointed to by `patharg`.
+ *
+ * Return 0 on success (or if no config entry for friends exists).
+ * Return -1 if we fail to open the file path.
+ * Return -2 if libconfig fails to read the config file.
+ *
+ * This function will have no effect on friends that are added in the future.
+ */
 int settings_load_friends(const char *patharg);
+
+/*
+ * Loads groupchat config settings from the toxic config file pointed to by `patharg`.
+ *
+ * Return 0 on success (or if no config entry for groupchats exists).
+ * Return -1 if we fail to open the file path.
+ * Return -2 if libconfig fails to read the config file.
+ *
+ * This function will have no effect on groupchat instances that are created in the future.
+ */
+int settings_load_groups(const char *patharg);
 
 #endif /* SETTINGS_H */

--- a/src/toxic.c
+++ b/src/toxic.c
@@ -1638,8 +1638,10 @@ int main(int argc, char **argv)
 
     const char *config_path = arg_opts.config_path[0] ? arg_opts.config_path : NULL;
 
-    if (settings_load_main(user_settings, config_path) == -1) {
-        queue_init_message("Failed to load user settings");
+    const int ms_ret = settings_load_main(user_settings, config_path);
+
+    if (ms_ret < 0) {
+        queue_init_message("Failed to load user settings: error %d", ms_ret);
     }
 
     const int curl_init = curl_global_init(CURL_GLOBAL_ALL);
@@ -1677,18 +1679,25 @@ int main(int argc, char **argv)
         arg_opts.encrypt_data = 0;
     }
 
-    const int fs_ret = settings_load_friends(config_path);
-
-    if (fs_ret != 0) {
-        queue_init_message("Failed to load friend config settings: error %d", fs_ret);
-    }
-
     init_term();
 
     prompt = init_windows(toxic->tox);
     prompt_init_statusbar(prompt, toxic->tox, !datafile_exists);
     load_groups(toxic->tox);
     load_conferences(toxic->tox);
+
+    const int fs_ret = settings_load_friends(config_path);
+
+    if (fs_ret != 0) {
+        queue_init_message("Failed to load friend config settings: error %d", fs_ret);
+    }
+
+    const int gs_ret = settings_load_groups(config_path);
+
+    if (gs_ret != 0) {
+        queue_init_message("Failed to load groupchat config settings: error %d", gs_ret);
+    }
+
     set_active_window_index(0);
 
     if (pthread_mutex_init(&Winthread.lock, NULL) != 0) {


### PR DESCRIPTION
Currently we only have one setting, but this can be expanded for other settings such as notifications, auto-logging etc.

This commit also bumps the C standard to c11 from c99 so we can use static_assert().

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/toxic/278)
<!-- Reviewable:end -->
