### PR TITLE
cleanup: fix some issues with customizable colours

### DIFF
--- a/doc/toxic.conf.5
+++ b/doc/toxic.conf.5
@@ -2,12 +2,12 @@
 .\"     Title: toxic.conf
 .\"    Author: [see the "AUTHORS" section]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 2024-01-17
+.\"      Date: 2024-01-18
 .\"    Manual: Toxic Manual
 .\"    Source: toxic __VERSION__
 .\"  Language: English
 .\"
-.TH "TOXIC\&.CONF" "5" "2024\-01\-17" "toxic __VERSION__" "Toxic Manual"
+.TH "TOXIC\&.CONF" "5" "2024\-01\-18" "toxic __VERSION__" "Toxic Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -304,7 +304,7 @@ Friend\-specific settings (prioritized over global settings)
 .PP
 \fBtab_name_colour\fR
 .RS 4
-The colour of the friend\(cqs tab window name\&. Valid colours are: white, red, green, cyan, purple, yellow, black\&.
+The colour of the friend\(cqs tab window name\&. (black, white, red, green, blue, cyan, yellow, magenta)
 .RE
 .PP
 \fBautolog\fR
@@ -319,7 +319,7 @@ Groupchat\-specific settings (prioritized over global settings)
 .PP
 \fBtab_name_colour\fR
 .RS 4
-The colour of the group\(cqs tab window name\&. Valid colours are: white, red, green, cyan, purple, yellow, black\&.
+The colour of the group\(cqs tab window name\&. (black, white, red, green, blue, cyan, yellow, magenta)
 .RE
 .PP
 \fBautolog\fR

--- a/doc/toxic.conf.5.asc
+++ b/doc/toxic.conf.5.asc
@@ -190,7 +190,7 @@ OPTIONS
     Friend-specific settings (prioritized over global settings)
 
     *tab_name_colour*;;
-        The colour of the friend's tab window name. Valid colours are: white, red, green, cyan, purple, yellow, black.
+        The colour of the friend's tab window name. (black, white, red, green, blue, cyan, yellow, magenta)
     *autolog*;;
         Enable or disable autologging. true or false
 
@@ -199,7 +199,7 @@ OPTIONS
     Groupchat-specific settings (prioritized over global settings)
 
     *tab_name_colour*;;
-        The colour of the group's tab window name. Valid colours are: white, red, green, cyan, purple, yellow, black.
+        The colour of the group's tab window name. (black, white, red, green, blue, cyan, yellow, magenta)
     *autolog*;;
         Enable or disable autologging. true or false
 

--- a/misc/toxic.conf.example
+++ b/misc/toxic.conf.example
@@ -20,7 +20,7 @@ ui = {
   // Output a bell when receiving a group/call invite (see manpage)
   bell_on_invite=true;
 
-  // true to use native terminal colours, false to use toxic default colour theme
+  // true to use native terminal colors, false to use toxic default color theme
   native_colors=false;
 
   // set background color of chat status bars (black, white, red, green, blue, cyan, yellow, magenta)
@@ -134,9 +134,9 @@ tox = {
 // and must begin with the prefix "pk_". These take priority over global settings.
 friends = {
   pk_PUBLIC_KEY_1 = {
-    // The colour of the friend's window tab name.
-    // Valid colours are: white, red, green, cyan, purple, yellow, black.
-    tab_name_colour="white";
+    // The color of the friend's window tab name.
+    // Valid colors are: black, white, red, green, blue, cyan, yellow, magenta.
+    tab_name_color="white";
 
     // Enable autologging for this friend
     autolog=false;
@@ -147,14 +147,14 @@ friends = {
 // };
 };
 
-// groupchat-specific config settings. Public keys (chat ID's) are used as
+// Groupchat-specific config settings. Public keys (chat ID's) are used as
 // group identifiers and must begin with the prefix "pk_". These take priority
 // over global settings.
 groupchats = {
   pk_PUBLIC_KEY_1 = {
-    // The colour of the group's window tab name.
-    // Valid colours are: white, red, green, cyan, purple, yellow, black.
-    tab_name_colour="white";
+    // The color of the group's window tab name.
+    // Valid colors are: black, white, red, green, blue, cyan, yellow, magenta.
+    tab_name_color="white";
 
     // Enable autologging for this group
     autolog=false;
@@ -163,7 +163,7 @@ groupchats = {
 // pk_PUBLIC_KEY_2 = {
 //   ...
 // };
-}
+};
 
 // To disable a sound set the path to "silent"
 sounds = {

--- a/src/chat.c
+++ b/src/chat.c
@@ -73,7 +73,7 @@ static const char *chat_cmd_list[] = {
     "/cjoin",
     "/clear",
     "/close",
-    "/colour",
+    "/color",
     "/connect",
     "/exit",
     "/gaccept",

--- a/src/conference.c
+++ b/src/conference.c
@@ -81,7 +81,7 @@ static const char *conference_cmd_list[] = {
     "/avatar",
     "/clear",
     "/close",
-    "/colour",
+    "/color",
     "/connect",
     "/decline",
     "/exit",

--- a/src/execute.c
+++ b/src/execute.c
@@ -45,7 +45,7 @@ static struct cmd_func global_commands[] = {
     { "/add",       cmd_add           },
     { "/avatar",    cmd_avatar        },
     { "/clear",     cmd_clear         },
-    { "/colour",    cmd_colour        },
+    { "/color",     cmd_color         },
     { "/connect",   cmd_connect       },
     { "/decline",   cmd_decline       },
     { "/exit",      cmd_quit          },

--- a/src/global_commands.c
+++ b/src/global_commands.c
@@ -252,14 +252,14 @@ void cmd_clear(WINDOW *window, ToxWindow *self, Tox *tox, int argc, char (*argv)
     force_refresh(window);
 }
 
-void cmd_colour(WINDOW *window, ToxWindow *self, Tox *tox, int argc, char (*argv)[MAX_STR_SIZE])
+void cmd_color(WINDOW *window, ToxWindow *self, Tox *tox, int argc, char (*argv)[MAX_STR_SIZE])
 {
     UNUSED_VAR(window);
     UNUSED_VAR(tox);
 
     if (argc != 1) {
         line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0,
-                      "Change the name of the focused window with /colour [white|black|yellow|red|green|cyan|purple]");
+                      "Change the name of the focused window with /color [black|white|red|green|blue|cyan|yellow|magenta)]");
         return;
     }
 
@@ -268,7 +268,7 @@ void cmd_colour(WINDOW *window, ToxWindow *self, Tox *tox, int argc, char (*argv
     const int colour_val = colour_string_to_int(colour);
 
     if (colour_val < 0) {
-        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Invalid colour");
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Invalid color");
         return;
     }
 

--- a/src/global_commands.h
+++ b/src/global_commands.h
@@ -30,7 +30,7 @@ void cmd_accept(WINDOW *, ToxWindow *, Tox *, int argc, char (*argv)[MAX_STR_SIZ
 void cmd_add(WINDOW *, ToxWindow *, Tox *, int argc, char (*argv)[MAX_STR_SIZE]);
 void cmd_avatar(WINDOW *window, ToxWindow *self, Tox *tox, int argc, char (*argv)[MAX_STR_SIZE]);
 void cmd_clear(WINDOW *, ToxWindow *, Tox *, int argc, char (*argv)[MAX_STR_SIZE]);
-void cmd_colour(WINDOW *window, ToxWindow *self, Tox *tox, int argc, char (*argv)[MAX_STR_SIZE]);
+void cmd_color(WINDOW *window, ToxWindow *self, Tox *tox, int argc, char (*argv)[MAX_STR_SIZE]);
 void cmd_conference(WINDOW *, ToxWindow *, Tox *, int argc, char (*argv)[MAX_STR_SIZE]);
 void cmd_connect(WINDOW *, ToxWindow *, Tox *, int argc, char (*argv)[MAX_STR_SIZE]);
 void cmd_decline(WINDOW *window, ToxWindow *self, Tox *tox, int argc, char (*argv)[MAX_STR_SIZE]);

--- a/src/groupchats.c
+++ b/src/groupchats.c
@@ -79,7 +79,7 @@ static const char *group_cmd_list[] = {
     "/chatid",
     "/clear",
     "/close",
-    "/colour",
+    "/color",
     "/conference",
     "/connect",
     "/disconnect",

--- a/src/help.c
+++ b/src/help.c
@@ -177,7 +177,7 @@ static void help_draw_global(ToxWindow *self)
     wprintw(win, "  /add <addr> <msg>          : Add contact with optional message\n");
     wprintw(win, "  /accept <id>               : Accept friend request\n");
     wprintw(win, "  /avatar <path>             : Set an avatar (leave path empty to unset)\n");
-    wprintw(win, "  /colour <c>                : Change the colour of the focused window's name\n");
+    wprintw(win, "  /color <color>             : Change the colour of the focused window's name\n");
     wprintw(win, "  /conference <type>         : Create a conference where type: text | audio\n");
     wprintw(win, "  /connect <ip> <port> <key> : Manually connect to a DHT node\n");
     wprintw(win, "  /decline <id>              : Decline friend request\n");

--- a/src/misc_tools.c
+++ b/src/misc_tools.c
@@ -774,12 +774,16 @@ int colour_string_to_int(const char *colour)
         return CYAN_BAR_FG;
     }
 
-    if (strcasecmp(colour, "purple") == 0) {
-        return PURPLE_BAR_FG;
+    if (strcasecmp(colour, "magenta") == 0) {
+        return MAGENTA_BAR_FG;
     }
 
     if (strcasecmp(colour, "black") == 0) {
         return BLACK_BAR_FG;
+    }
+
+    if (strcasecmp(colour, "blue") == 0) {
+        return BLUE_BAR_FG;
     }
 
     return -1;

--- a/src/misc_tools.h
+++ b/src/misc_tools.h
@@ -255,7 +255,7 @@ unsigned int rand_not_secure(void);
  * Returns an integer associated with an ncurses foreground colour, per the C_COLOURS enum
  * in windows.h.
  *
- * Valid colour strings are: white, red, green, cyan, purple, yellow, black.
+ * Valid colour strings are: black, white, red, green, blue, cyan, yellow, magenta.
  *
  * Returns -1 if colour is invalid.
  */

--- a/src/prompt.c
+++ b/src/prompt.c
@@ -56,7 +56,7 @@ static const char *glob_cmd_list[] = {
     "/add",
     "/avatar",
     "/clear",
-    "/colour",
+    "/color",
     "/connect",
     "/decline",
     "/exit",

--- a/src/settings.c
+++ b/src/settings.c
@@ -277,21 +277,21 @@ static const struct sound_strings {
 
 static const struct friend_strings {
     const char *self;
-    const char *tab_name_colour;
+    const char *tab_name_color;
     const char *autolog;
 } friend_strings = {
     "friends",
-    "tab_name_colour",
+    "tab_name_color",
     "autolog",
 };
 
 static const struct groupchat_strings {
     const char *self;
-    const char *tab_name_colour;
+    const char *tab_name_color;
     const char *autolog;
 } groupchat_strings = {
     "groupchats",
-    "tab_name_colour",
+    "tab_name_color",
     "autolog",
 };
 
@@ -425,9 +425,9 @@ int settings_load_groups(const char *patharg)
             continue;
         }
 
-        if (config_setting_lookup_string(keys, groupchat_strings.tab_name_colour, &str)) {
+        if (config_setting_lookup_string(keys, groupchat_strings.tab_name_color, &str)) {
             if (!groupchat_config_set_tab_name_colour(public_key, str)) {
-                fprintf(stderr, "config error: failed to set groupchat tab name colour for %s: (colour: %s)\n", public_key, str);
+                fprintf(stderr, "config error: failed to set groupchat tab name color for %s: (color: %s)\n", public_key, str);
             }
         }
 
@@ -484,9 +484,9 @@ int settings_load_friends(const char *patharg)
             continue;
         }
 
-        if (config_setting_lookup_string(keys, friend_strings.tab_name_colour, &str)) {
+        if (config_setting_lookup_string(keys, friend_strings.tab_name_color, &str)) {
             if (!friend_config_set_tab_name_colour(public_key, str)) {
-                fprintf(stderr, "config error: failed to set friend tab name colour for %s: (colour: %s)\n", public_key, str);
+                fprintf(stderr, "config error: failed to set friend tab name color for %s: (color: %s)\n", public_key, str);
             }
         }
 

--- a/src/toxic.c
+++ b/src/toxic.c
@@ -434,7 +434,7 @@ static void init_term(void)
         init_pair(WHITE_BLACK, COLOR_WHITE, COLOR_BLACK);
         init_pair(WHITE_GREEN, COLOR_WHITE, COLOR_GREEN);
         init_pair(BLACK_BG, COLOR_BLACK, bar_bg_color);
-        init_pair(PURPLE_BG, COLOR_MAGENTA, bar_bg_color);
+        init_pair(MAGENTA_BG, COLOR_MAGENTA, bar_bg_color);
         init_pair(BAR_TEXT, bar_fg_color, bar_bg_color);
         init_pair(BAR_SOLID, bar_bg_color, bar_bg_color);
         init_pair(BAR_ACCENT, bar_accent_color, bar_bg_color);
@@ -442,13 +442,14 @@ static void init_term(void)
         init_pair(STATUS_ONLINE, COLOR_GREEN, bar_bg_color);
         init_pair(STATUS_AWAY, COLOR_YELLOW, bar_bg_color);
         init_pair(STATUS_BUSY, COLOR_RED, bar_bg_color);
+        init_pair(BLACK_BAR_FG, COLOR_BLACK, bar_bg_color);
         init_pair(WHITE_BAR_FG, COLOR_WHITE, bar_bg_color);
         init_pair(RED_BAR_FG, COLOR_RED, bar_bg_color);
         init_pair(GREEN_BAR_FG, COLOR_GREEN, bar_bg_color);
+        init_pair(BLUE_BAR_FG, COLOR_BLUE, bar_bg_color);
         init_pair(CYAN_BAR_FG, COLOR_CYAN, bar_bg_color);
-        init_pair(PURPLE_BAR_FG, COLOR_MAGENTA, bar_bg_color);
         init_pair(YELLOW_BAR_FG, COLOR_YELLOW, bar_bg_color);
-        init_pair(BLACK_BAR_FG, COLOR_BLACK, bar_bg_color);
+        init_pair(MAGENTA_BAR_FG, COLOR_MAGENTA, bar_bg_color);
     }
 
     refresh();

--- a/src/windows.h
+++ b/src/windows.h
@@ -67,19 +67,20 @@ typedef enum {
     BAR_TEXT,
     STATUS_ONLINE,
     BAR_ACCENT,
-    PURPLE_BG,
+    MAGENTA_BG,
     BLACK_BG,
     STATUS_BUSY,
     STATUS_AWAY,
     BAR_NOTIFY,
     BAR_SOLID,
+    BLACK_BAR_FG,
     WHITE_BAR_FG,
     RED_BAR_FG,
     GREEN_BAR_FG,
+    BLUE_BAR_FG,
     CYAN_BAR_FG,
-    PURPLE_BAR_FG,
     YELLOW_BAR_FG,
-    BLACK_BAR_FG,
+    MAGENTA_BAR_FG,
 } C_COLOURS;
 
 /* tab alert types: lower types take priority (this relies on the order of C_COLOURS) */
@@ -87,7 +88,7 @@ typedef enum {
     WINDOW_ALERT_NONE = 0,
     WINDOW_ALERT_0 = STATUS_ONLINE,
     WINDOW_ALERT_1 = BAR_ACCENT,
-    WINDOW_ALERT_2 = PURPLE_BG,
+    WINDOW_ALERT_2 = MAGENTA_BG,
 } WINDOW_ALERTS;
 
 typedef enum {


### PR DESCRIPTION
- Add blue for tab name colours
- change all instances of purple to magenta to be consistent with
both ncurses and other parts of toxic
- Use color instead of colour for all user-facing variables
and messages in order to be consistent with previous spelling
conventions
- Sort colours the same way everywhere

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/toxic/281)
<!-- Reviewable:end -->
