### PR TITLE
fix: group/conference peerlist border colors

### DIFF
--- a/src/conference.c
+++ b/src/conference.c
@@ -1088,10 +1088,10 @@ static void conference_onDraw(ToxWindow *self, Tox *tox)
     wclear(ctx->sidebar);
 
     if (self->show_peerlist) {
-        wattron(ctx->sidebar, COLOR_PAIR(BLUE));
+        wattron(ctx->sidebar, COLOR_PAIR(PEERLIST_LINE));
         mvwvline(ctx->sidebar, 0, 0, ACS_VLINE, y2 - CHATBOX_HEIGHT);
         mvwaddch(ctx->sidebar, y2 - CHATBOX_HEIGHT, 0, ACS_BTEE);
-        wattroff(ctx->sidebar, COLOR_PAIR(BLUE));
+        wattroff(ctx->sidebar, COLOR_PAIR(PEERLIST_LINE));
 
         pthread_mutex_lock(&Winthread.lock);
         const uint32_t num_peers = chat->num_peers;
@@ -1151,10 +1151,10 @@ static void conference_onDraw(ToxWindow *self, Tox *tox)
         wattroff(ctx->sidebar, A_BOLD);
         ++line;
 
-        wattron(ctx->sidebar, COLOR_PAIR(BLUE));
+        wattron(ctx->sidebar, COLOR_PAIR(PEERLIST_LINE));
         mvwaddch(ctx->sidebar, line, 0, ACS_LTEE);
         mvwhline(ctx->sidebar, line, 1, ACS_HLINE, SIDEBAR_WIDTH - 1);
-        wattroff(ctx->sidebar, COLOR_PAIR(BLUE));
+        wattroff(ctx->sidebar, COLOR_PAIR(PEERLIST_LINE));
         ++line;
 
         for (uint32_t i = 0;

--- a/src/global_commands.c
+++ b/src/global_commands.c
@@ -259,7 +259,7 @@ void cmd_color(WINDOW *window, ToxWindow *self, Tox *tox, int argc, char (*argv)
 
     if (argc != 1) {
         line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0,
-                      "Change the name of the focused window with /color [black|white|red|green|blue|cyan|yellow|magenta)]");
+                      "Change the name of the focused window with: /color [black|white|red|green|blue|cyan|yellow|magenta]");
         return;
     }
 
@@ -268,7 +268,8 @@ void cmd_color(WINDOW *window, ToxWindow *self, Tox *tox, int argc, char (*argv)
     const int colour_val = colour_string_to_int(colour);
 
     if (colour_val < 0) {
-        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Invalid color");
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0,
+                      "Invalid color. Valid colors are: black|white|red|green|blue|cyan|yellow|magenta");
         return;
     }
 

--- a/src/groupchats.c
+++ b/src/groupchats.c
@@ -1937,10 +1937,10 @@ static void groupchat_onDraw(ToxWindow *self, Tox *tox)
     wclear(ctx->sidebar);
 
     if (self->show_peerlist) {
-        wattron(ctx->sidebar, COLOR_PAIR(BLUE));
+        wattron(ctx->sidebar, COLOR_PAIR(PEERLIST_LINE));
         mvwvline(ctx->sidebar, 0, 0, ACS_VLINE, y2 - CHATBOX_HEIGHT);
         mvwaddch(ctx->sidebar, y2 - CHATBOX_HEIGHT, 0, ACS_BTEE);
-        wattroff(ctx->sidebar, COLOR_PAIR(BLUE));
+        wattroff(ctx->sidebar, COLOR_PAIR(PEERLIST_LINE));
 
         wmove(ctx->sidebar, 0, 1);
         wattron(ctx->sidebar, A_BOLD);
@@ -1959,10 +1959,10 @@ static void groupchat_onDraw(ToxWindow *self, Tox *tox)
 
         wattroff(ctx->sidebar, A_BOLD);
 
-        wattron(ctx->sidebar, COLOR_PAIR(BLUE));
+        wattron(ctx->sidebar, COLOR_PAIR(PEERLIST_LINE));
         mvwaddch(ctx->sidebar, 1, 0, ACS_LTEE);
         mvwhline(ctx->sidebar, 1, 1, ACS_HLINE, SIDEBAR_WIDTH - 1);
-        wattroff(ctx->sidebar, COLOR_PAIR(BLUE));
+        wattroff(ctx->sidebar, COLOR_PAIR(PEERLIST_LINE));
 
         const int maxlines = y2 - GROUP_SIDEBAR_OFFSET - CHATBOX_HEIGHT;
         uint32_t offset = 0;

--- a/src/toxic.c
+++ b/src/toxic.c
@@ -439,6 +439,7 @@ static void init_term(void)
         init_pair(BAR_SOLID, bar_bg_color, bar_bg_color);
         init_pair(BAR_ACCENT, bar_accent_color, bar_bg_color);
         init_pair(BAR_NOTIFY, bar_notify_color, bar_bg_color);
+        init_pair(PEERLIST_LINE, bar_bg_color, bg_color);
         init_pair(STATUS_ONLINE, COLOR_GREEN, bar_bg_color);
         init_pair(STATUS_AWAY, COLOR_YELLOW, bar_bg_color);
         init_pair(STATUS_BUSY, COLOR_RED, bar_bg_color);

--- a/src/windows.h
+++ b/src/windows.h
@@ -72,6 +72,7 @@ typedef enum {
     STATUS_BUSY,
     STATUS_AWAY,
     BAR_NOTIFY,
+    PEERLIST_LINE,
     BAR_SOLID,
     BLACK_BAR_FG,
     WHITE_BAR_FG,


### PR DESCRIPTION
The line colours now match the custom set colour scheme

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/toxic/282)
<!-- Reviewable:end -->
