### PR TITLE
fix: don't report an error when blocklist file doesn't exist

### DIFF
--- a/src/friendlist.c
+++ b/src/friendlist.c
@@ -263,6 +263,11 @@ int load_blocklist(char *path)
         return -1;
     }
 
+    if (!file_exists(path)) {
+        fprintf(stderr, "block list file `%s` doesn't exist\n", path);
+        return 0;
+    }
+
     FILE *fp = fopen(path, "rb");
 
     if (fp == NULL) {

--- a/src/friendlist.h
+++ b/src/friendlist.h
@@ -123,11 +123,19 @@ ToxWindow *new_friendlist(void);
 void friendlist_onInit(ToxWindow *self, Toxic *toxic);
 void disable_chatwin(uint32_t f_num);
 int get_friendnum(uint8_t *name);
-int load_blocklist(char *data);
 void kill_friendlist(ToxWindow *self);
 void friendlist_onFriendAdded(ToxWindow *self, Toxic *toxic, uint32_t num, bool sort);
 Tox_User_Status get_friend_status(uint32_t friendnumber);
 Tox_Connection get_friend_connection_status(uint32_t friendnumber);
+
+/*
+ * Loads the list of blocked peers from `path`.
+ *
+ * Returns 0 on success or if the file doesn't exist (a file will only exist if
+ *   the client has actually blocked someone).
+ * Returns -1 on failure.
+ */
+int load_blocklist(char *path);
 
 /* sorts friendlist_index first by connection status then alphabetically */
 void sort_friendlist_index(void);

--- a/src/toxic.c
+++ b/src/toxic.c
@@ -1198,7 +1198,6 @@ static bool load_toxic(Toxic *toxic)
 
     tox_options_free(tox_opts);
 
-    fprintf(stderr, "a%p\n", (void *)toxic->tox);
     return true;
 }
 


### PR DESCRIPTION
The blocklist file is only ever created if the client blocks someone.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/toxic/287)
<!-- Reviewable:end -->
