### PR TITLE
refactor: simplify error handling in name lookup thread

### DIFF
--- a/src/bootstrap.c
+++ b/src/bootstrap.c
@@ -589,7 +589,7 @@ void *load_nodeslist_thread(void *data)
 on_exit:
     thread_data.active = false;
     pthread_attr_destroy(&thread_data.attr);
-    pthread_exit(0);
+    pthread_exit(NULL);
 }
 
 /* Creates a new thread that will load the DHT nodeslist to memory


### PR DESCRIPTION
This makes it more clear to static analysers that the function actually exits after an error.

@robinlinden suggested marking the thread as `_Noreturn`, and while that worked in suppressing the false positive, it was also suppressing some ugly/confusing code.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/toxic/291)
<!-- Reviewable:end -->
