### PR TITLE
feat: tab-complete will now work for command arguments

### DIFF
--- a/src/chat.c
+++ b/src/chat.c
@@ -1357,14 +1357,7 @@ bool chat_onKey(ToxWindow *self, Toxic *toxic, wint_t key, bool ltr)
 
 #endif
 
-        else if (wcsncmp(ctx->line, L"/status ", wcslen(L"/status ")) == 0) {
-            const char *status_cmd_list[] = {
-                "online",
-                "away",
-                "busy",
-            };
-            diff = complete_line(self, toxic, status_cmd_list, sizeof(status_cmd_list) / sizeof(char *));
-        } else {
+        else {
             diff = complete_line(self, toxic, chat_cmd_list, sizeof(chat_cmd_list) / sizeof(char *));
         }
 

--- a/src/game_base.c
+++ b/src/game_base.c
@@ -118,7 +118,7 @@ void game_list_print(ToxWindow *self, const Client_Config *c_config)
     const char *name = NULL;
 
     for (size_t i = 0; (name = game_list[i].name); ++i) {
-        line_info_add(self, c_config, false, NULL, NULL, SYS_MSG, 0, 0, "%zu: %s", i + 1, name);
+        line_info_add(self, c_config, false, NULL, NULL, SYS_MSG, 0, 0, "- %s", name);
     }
 }
 

--- a/src/help.c
+++ b/src/help.c
@@ -191,7 +191,7 @@ static void help_draw_global(ToxWindow *self)
     wprintw(win, "  /group <name>              : Create a new group chat\n");
     wprintw(win, "  /join <chatid>             : Join a public groupchat using a Chat ID\n");
 #ifdef GAMES
-    wprintw(win, "  /game                      : Play a game\n");
+    wprintw(win, "  /game <name>               : Play a game\n");
 #endif /* GAMES */
 
 #ifdef QRCODE
@@ -256,6 +256,10 @@ static void help_draw_chat(ToxWindow *self)
     wprintw(win, "  /savefile <id>             : Receive a file\n");
     wprintw(win, "  /cancel <type> <id>        : Cancel file transfer where type: in|out\n");
 
+#ifdef GAMES
+    wprintw(win, "  /game <name>               : Play a game with this contact\n");
+#endif /* GAMES */
+
 #ifdef AUDIO
     wattron(win, A_BOLD);
     wprintw(win, "\n Audio:\n");
@@ -279,10 +283,6 @@ static void help_draw_chat(ToxWindow *self)
     wprintw(win, "  /vcall                     : Video call\n");
     wprintw(win, "  /video                     : Toggle video in call\n");
 #endif /* VIDEO */
-
-#ifdef GAMES
-    wprintw(win, "  /game                      : Play a game with contact\n");
-#endif /* GAMES */
 
     help_draw_bottom_menu(win);
 

--- a/src/prompt.c
+++ b/src/prompt.c
@@ -262,14 +262,7 @@ static bool prompt_onKey(ToxWindow *self, Toxic *toxic, wint_t key, bool ltr)
 
 #endif
 
-            else if (wcsncmp(ctx->line, L"/status ", wcslen(L"/status ")) == 0) {
-                const char *status_cmd_list[] = {
-                    "online",
-                    "away",
-                    "busy",
-                };
-                diff = complete_line(self, toxic, status_cmd_list, sizeof(status_cmd_list) / sizeof(char *));
-            } else {
+            else {
                 diff = complete_line(self, toxic, glob_cmd_list, sizeof(glob_cmd_list) / sizeof(char *));
             }
 


### PR DESCRIPTION
This was done in a half-assed way for statuses (only worked in the chat and home windows). Now it's done globally for all '/status', '/game', and '/color' command arguments

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/toxic/295)
<!-- Reviewable:end -->
