### PR TITLE
feat: config files are now tied to tox data files by default

### DIFF
--- a/src/bootstrap.c
+++ b/src/bootstrap.c
@@ -36,6 +36,7 @@
 #include "line_info.h"
 #include "misc_tools.h"
 #include "prompt.h"
+#include "run_options.h"
 #include "settings.h"
 #include "windows.h"
 

--- a/src/misc_tools.c
+++ b/src/misc_tools.c
@@ -559,7 +559,7 @@ size_t copy_tox_str(char *msg, size_t size, const char *data, size_t length)
    returns length of s if char not found or 0 if s is NULL. */
 int char_find(int idx, const char *s, char ch)
 {
-    if (!s) {
+    if (s == NULL) {
         return 0;
     }
 
@@ -578,7 +578,7 @@ int char_find(int idx, const char *s, char ch)
    returns 0 if char not found or s is NULL (skips 0th index). */
 int char_rfind(const char *s, char ch, int len)
 {
-    if (!s) {
+    if (s == NULL) {
         return 0;
     }
 

--- a/src/name_lookup.c
+++ b/src/name_lookup.c
@@ -30,6 +30,7 @@
 #include "global_commands.h"
 #include "line_info.h"
 #include "misc_tools.h"
+#include "run_options.h"
 #include "toxic.h"
 #include "windows.h"
 

--- a/src/run_options.h
+++ b/src/run_options.h
@@ -1,0 +1,57 @@
+/*  run_options.h
+ *
+ *
+ *  Copyright (C) 2024 Toxic All Rights Reserved.
+ *
+ *  This file is part of Toxic.
+ *
+ *  Toxic is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Toxic is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Toxic.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef RUN_OPTIONS_H
+
+#include <stdbool.h>
+#include <stdio.h>  // needed for FILE
+#include <stdint.h>
+
+#include "toxic_constants.h"
+
+typedef struct Run_Options {
+    bool use_ipv4;
+    bool force_tcp;
+    bool disable_local_discovery;
+    bool debug;
+    bool default_locale;
+    bool use_custom_data;
+    bool use_custom_config_file;
+    bool no_connect;
+    bool encrypt_data;
+    bool unencrypt_data;
+
+    char nameserver_path[MAX_STR_SIZE];
+    char config_path[MAX_STR_SIZE];
+    char nodes_path[MAX_STR_SIZE];
+
+    bool logging;
+    FILE *log_fp;
+
+    char proxy_address[256];
+    uint8_t proxy_type;
+    uint16_t proxy_port;
+
+    uint16_t tcp_port;
+} Run_Options;
+
+#endif /* RUN_OPTIONS_H */

--- a/src/settings.h
+++ b/src/settings.h
@@ -141,6 +141,27 @@ enum settings_values {
 #define LOG_TIMESTAMP_DEFAULT  "%Y/%m/%d [%H:%M:%S]"
 #define MPLEX_AWAY_NOTE "Away from keyboard, be back soon!"
 
+typedef struct Run_Options Run_Options;
+
+/*
+ * Loads the config file into `run_opts` and creates an empty file if it does not
+ * already exist. This function must be called before any other `settings_load` function.
+ *
+ * If the client has set a custom config file via the run option it will be
+ * prioritized.
+ *
+ * If the client is using the default tox data file and has not specified a custom
+ * config file, the default config file in the user config directory is used
+ *
+ * If the client is using a custom tox data file, the config path and filename will be
+ * identical to those of the data file, but with a `.conf` file extension.
+ *
+ * `data_path` is the name of the tox profile being used.
+ *
+ * Returns true if config file is successfully loaded.
+ */
+bool settings_load_config_file(Run_Options *run_opts, const char *data_path);
+
 /*
  * Loads general toxic settings from the toxic config file pointed to by `patharg'.
  *
@@ -148,7 +169,7 @@ enum settings_values {
  * Return -1 if we fail to open the file path.
  * Return -2 if libconfig fails to read the config file.
  */
-int settings_load_main(Client_Config *s, const char *patharg);
+int settings_load_main(Client_Config *s, const Run_Options *run_opts);
 
 /*
  * Loads friend config settings from the toxic config file pointed to by `patharg`.
@@ -160,7 +181,7 @@ int settings_load_main(Client_Config *s, const char *patharg);
  *
  * This function will have no effect on friends that are added in the future.
  */
-int settings_load_friends(const char *patharg);
+int settings_load_friends(const Run_Options *run_opts);
 
 /*
  * Loads groupchat config settings from the toxic config file pointed to by `patharg`.
@@ -172,7 +193,7 @@ int settings_load_friends(const char *patharg);
  *
  * This function will have no effect on groupchat instances that are created in the future.
  */
-int settings_load_groups(const char *patharg);
+int settings_load_groups(const Run_Options *run_opts);
 
 /*
  * Loads conference config settings from the toxic config file pointed to by `patharg`.
@@ -184,6 +205,6 @@ int settings_load_groups(const char *patharg);
  *
  * This function will have no effect on conference instances that are created in the future.
  */
-int settings_load_conferences(const char *patharg);
+int settings_load_conferences(const Run_Options *run_opts);
 
 #endif /* SETTINGS_H */

--- a/src/toxic.h
+++ b/src/toxic.h
@@ -51,31 +51,6 @@
 #include "settings.h"
 #include "toxic_constants.h"
 
-typedef struct Run_Options {
-    bool use_ipv4;
-    bool force_tcp;
-    bool disable_local_discovery;
-    bool debug;
-    bool default_locale;
-    bool use_custom_data;
-    bool no_connect;
-    bool encrypt_data;
-    bool unencrypt_data;
-
-    char nameserver_path[MAX_STR_SIZE];
-    char config_path[MAX_STR_SIZE];
-    char nodes_path[MAX_STR_SIZE];
-
-    bool logging;
-    FILE *log_fp;
-
-    char proxy_address[256];
-    uint8_t proxy_type;
-    uint16_t proxy_port;
-
-    uint16_t tcp_port;
-} Run_Options;
-
 typedef struct Client_Data {
     bool is_encrypted;
     char pass[MAX_PASSWORD_LEN + 1];
@@ -86,6 +61,7 @@ typedef struct Client_Data {
 
 typedef struct ToxAV ToxAV;
 typedef struct ToxWindow ToxWindow;
+typedef struct Run_Options Run_Options;
 
 typedef struct Toxic {
     Tox   *tox;


### PR DESCRIPTION
Instead of using the same default config file for every profile we now use the same name and path as the custom tox profile (with a .conf file extension), and create an empty config file if it doesn't already exist. In addition, if the user passes a non-existent file as a run option, we now create an empty file instead of returning an error.

Behaviour should not be changed for default profiles.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/toxic/300)
<!-- Reviewable:end -->
