### PR TITLE
fix: friend tab names default colour now matches custom themes

### DIFF
--- a/src/friendlist.c
+++ b/src/friendlist.c
@@ -66,7 +66,7 @@ static struct PendingDel {
 
 typedef enum Default_Conf {
     Default_Conf_Auto_Accept_Files = 0,
-    Default_Conf_Tab_Name_Colour = WHITE_BAR_FG,
+    Default_Conf_Tab_Name_Colour = BAR_TEXT,
 } Default_Conf;
 
 static void set_default_friend_config_settings(ToxicFriend *friend, const Client_Config *c_config)


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/toxic/322)
<!-- Reviewable:end -->
