### PR TITLE
chore: Don't use cirrus cache for bazel.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,5 +8,4 @@ bazel-opt_task:
     - /src/workspace/tools/inject-repo toxic
   test_all_script:
     - cd /src/workspace && bazel test -k
-        --remote_http_cache=http://$CIRRUS_HTTP_CACHE_HOST
         //toxic/...


### PR DESCRIPTION
It's unreliable.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/toxic/325)
<!-- Reviewable:end -->
