### PR TITLE
cleanup: string arrays now contain const strings

### DIFF
--- a/src/autocomplete.c
+++ b/src/autocomplete.c
@@ -106,7 +106,7 @@ static int complete_line_helper(ToxWindow *self, Toxic *toxic, const char *const
 {
     ChatContext *ctx = self->chatwin;
 
-    if (ctx->pos <= 0 || ctx->len <= 0 || ctx->pos > ctx->len) {
+    if (ctx->pos <= 0 || ctx->len <= 1 || ctx->pos > ctx->len) {
         return -1;
     }
 
@@ -269,7 +269,7 @@ static int complete_line_helper(ToxWindow *self, Toxic *toxic, const char *const
     return diff;
 }
 
-static const char *color_list[] = {
+static const char *const color_list[] = {
     "black",
     "blue",
     "brown",
@@ -284,14 +284,14 @@ static const char *color_list[] = {
     "yellow",
 };
 
-static const char *game_list[] = {
+static const char *const game_list[] = {
     "centipede",
     "chess",
     "life",
     "snake",
 };
 
-static const char *status_list[] = {
+static const char *const status_list[] = {
     "away",
     "busy",
     "online",

--- a/src/chat.c
+++ b/src/chat.c
@@ -65,7 +65,7 @@ static void kill_infobox(ToxWindow *self);
 #endif /* AUDIO */
 
 /* Array of chat command names used for tab completion. */
-static const char *chat_cmd_list[] = {
+static const char *const chat_cmd_list[] = {
     "/accept",
     "/add",
     "/autoaccept",
@@ -1306,7 +1306,10 @@ static bool chat_onKey(ToxWindow *self, Toxic *toxic, wint_t key, bool ltr)
     ChatContext *ctx = self->chatwin;
     StatusBar *statusbar = self->stb;
 
-    int x, y, y2, x2;
+    int x;
+    int y;
+    int y2;
+    int x2;
     getyx(self->window, y, x);
     getmaxyx(self->window, y2, x2);
 
@@ -1365,7 +1368,7 @@ static bool chat_onKey(ToxWindow *self, Toxic *toxic, wint_t key, bool ltr)
 
         if (diff != -1) {
             if (x + diff > x2 - 1) {
-                int wlen = MAX(0, wcswidth(ctx->line, sizeof(ctx->line) / sizeof(wchar_t)));
+                const int wlen = MAX(0, wcswidth(ctx->line, sizeof(ctx->line) / sizeof(wchar_t)));
                 ctx->start = wlen < x2 ? 0 : wlen - x2 + 1;
             }
         } else {
@@ -1400,10 +1403,10 @@ static bool chat_onKey(ToxWindow *self, Toxic *toxic, wint_t key, bool ltr)
                 char selfname[TOX_MAX_NAME_LENGTH];
                 tox_self_get_name(tox, (uint8_t *) selfname);
 
-                size_t len = tox_self_get_name_size(tox);
+                const size_t len = tox_self_get_name_size(tox);
                 selfname[len] = '\0';
 
-                int id = line_info_add(self, c_config, true, selfname, NULL, OUT_MSG, 0, 0, "%s", line);
+                const int id = line_info_add(self, c_config, true, selfname, NULL, OUT_MSG, 0, 0, "%s", line);
                 cqueue_add(ctx->cqueue, line, strlen(line), OUT_MSG, id);
             } else {
                 line_info_add(self, c_config, false, NULL, NULL, SYS_MSG, 0, RED, " * Failed to parse message.");

--- a/src/conference.c
+++ b/src/conference.c
@@ -73,7 +73,7 @@ extern struct Winthread Winthread;
 static_assert(TOX_CONFERENCE_ID_SIZE == TOX_PUBLIC_KEY_SIZE, "TOX_CONFERENCE_ID_SIZE != TOX_PUBLIC_KEY_SIZE");
 
 /* Array of conference command names used for tab completion. */
-static const char *conference_cmd_list[] = {
+static const char *const conference_cmd_list[] = {
     "/accept",
     "/add",
 #ifdef AUDIO

--- a/src/execute.c
+++ b/src/execute.c
@@ -36,7 +36,7 @@
 #include "windows.h"
 
 struct cmd_func {
-    const char *name;
+    const char *const name;
     void (*func)(WINDOW *w, ToxWindow *, Toxic *toxic, int argc, char (*argv)[MAX_STR_SIZE]);
 };
 

--- a/src/groupchats.c
+++ b/src/groupchats.c
@@ -71,7 +71,7 @@ extern struct Winthread Winthread;
 static_assert(TOX_GROUP_CHAT_ID_SIZE == TOX_PUBLIC_KEY_SIZE, "TOX_GROUP_CHAT_ID_SIZE != TOX_PUBLIC_KEY_SIZE");
 
 /* groupchat command names used for tab completion. */
-static const char *group_cmd_list[] = {
+static const char *const group_cmd_list[] = {
     "/accept",
     "/add",
     "/avatar",

--- a/src/prompt.c
+++ b/src/prompt.c
@@ -49,7 +49,7 @@ extern FriendsList Friends;
 FriendRequests FrndRequests;
 
 /* Array of global command names used for tab completion. */
-static const char *glob_cmd_list[] = {
+static const char *const glob_cmd_list[] = {
     "/accept",
     "/add",
     "/avatar",


### PR DESCRIPTION
This commit also fixes an issue where trying to autocomplete a lone forward-slash will spam the window with every possible command

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/toxic/327)
<!-- Reviewable:end -->
