### PR TITLE
feat: re-colourize chat history on load

### DIFF
--- a/doc/toxic.conf.5
+++ b/doc/toxic.conf.5
@@ -2,12 +2,12 @@
 .\"     Title: toxic.conf
 .\"    Author: [see the "AUTHORS" section]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 2024-02-07
+.\"      Date: 2024-02-17
 .\"    Manual: Toxic Manual
 .\"    Source: toxic __VERSION__
 .\"  Language: English
 .\"
-.TH "TOXIC\&.CONF" "5" "2024\-02\-07" "toxic __VERSION__" "Toxic Manual"
+.TH "TOXIC\&.CONF" "5" "2024\-02\-17" "toxic __VERSION__" "Toxic Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -79,7 +79,7 @@ Time format string for the interface enclosed by double quotes\&. See
 .PP
 \fBlog_timestamp_format\fR
 .RS 4
-Time format string for logging enclosed by double quotes\&. See
+Time format string for logging enclosed by double quotes\&. (Note: the time portion of the format string must be enclosed by square brackets in order to be parsed by toxic)\&. See
 \fBdate\fR(1)
 .RE
 .PP

--- a/doc/toxic.conf.5.asc
+++ b/doc/toxic.conf.5.asc
@@ -51,7 +51,7 @@ OPTIONS
         See *date*(1)
 
     *log_timestamp_format*;;
-        Time format string for logging enclosed by double quotes.
+        Time format string for logging enclosed by double quotes. (Note: the time portion of the format string must be enclosed by square brackets in order to be parsed by toxic).
         See *date*(1)
 
     *alerts*;;

--- a/misc/toxic.conf.example
+++ b/misc/toxic.conf.example
@@ -51,6 +51,10 @@ ui = {
   // Timestamp format string according to date/strftime format. Overrides time_format setting
   timestamp_format="%H:%M";
 
+  // Timestamp format string for raw logs according to date/strftime format. (Note: the time
+  // of the format string must be enclosed in square brackets in order to be parsed by toxic).
+  log_timestamp_format="%Y/%m/%d [%H:%M]"
+
   // true to show you when others are typing a message in 1-on-1 chats
   show_typing_other=true;
 

--- a/src/chat.c
+++ b/src/chat.c
@@ -21,7 +21,7 @@
  */
 
 #ifndef _GNU_SOURCE
-#define _GNU_SOURCE    /* needed for wcswidth() */
+#define _GNU_SOURCE    /* needed for strcasestr() and wcswidth() */
 #endif
 
 #include "chat.h"
@@ -1647,18 +1647,26 @@ static void chat_onDraw(ToxWindow *self, Toxic *toxic)
 
 static void chat_init_log(ToxWindow *self, Toxic *toxic, const char *self_nick)
 {
+    Tox *tox = toxic->tox;
+
     ChatContext *ctx = self->chatwin;
     const Client_Config *c_config = toxic->c_config;
 
     char myid[TOX_ADDRESS_SIZE];
-    tox_self_get_address(toxic->tox, (uint8_t *) myid);
+    tox_self_get_address(tox, (uint8_t *) myid);
+
+    char self_name[TOX_MAX_NAME_LENGTH + 1];
+    tox_self_get_name(tox, (uint8_t *) self_name);
+
+    const size_t len = tox_self_get_name_size(tox);
+    self_name[len] = '\0';
 
     if (log_init(ctx->log, c_config, self_nick, myid, Friends.list[self->num].pub_key, LOG_TYPE_CHAT) != 0) {
         line_info_add(self, c_config, false, NULL, NULL, SYS_MSG, 0, 0, "Failed to initialize chat log.");
         return;
     }
 
-    if (load_chat_history(ctx->log, self, c_config) != 0) {
+    if (load_chat_history(ctx->log, self, c_config, self_name) != 0) {
         line_info_add(self, c_config, false, NULL, NULL, SYS_MSG, 0, 0, "Failed to load chat history.");
     }
 

--- a/src/conference.c
+++ b/src/conference.c
@@ -179,6 +179,12 @@ static void init_conference_logging(ToxWindow *self, Toxic *toxic, uint32_t conf
     char my_id[TOX_ADDRESS_SIZE];
     tox_self_get_address(tox, (uint8_t *) my_id);
 
+    char self_name[TOX_MAX_NAME_LENGTH + 1];
+    tox_self_get_name(tox, (uint8_t *) self_name);
+
+    const size_t len = tox_self_get_name_size(tox);
+    self_name[len] = '\0';
+
     char conference_id[TOX_CONFERENCE_ID_SIZE];
     tox_conference_get_id(tox, conferencenum, (uint8_t *) conference_id);
 
@@ -187,7 +193,7 @@ static void init_conference_logging(ToxWindow *self, Toxic *toxic, uint32_t conf
         return;
     }
 
-    if (load_chat_history(ctx->log, self, c_config) != 0) {
+    if (load_chat_history(ctx->log, self, c_config, self_name) != 0) {
         line_info_add(self, c_config, false, NULL, NULL, SYS_MSG, 0, 0, "Failed to load chat history.");
     }
 

--- a/src/groupchats.c
+++ b/src/groupchats.c
@@ -338,6 +338,9 @@ static void init_groupchat_log(ToxWindow *self, Toxic *toxic, uint32_t groupnumb
     char my_id[TOX_ADDRESS_SIZE];
     tox_self_get_address(tox, (uint8_t *) my_id);
 
+    char self_nick[TOX_MAX_NAME_LENGTH + 1];
+    get_group_self_nick_truncate(tox, self_nick, groupnumber);
+
     char chat_id[TOX_GROUP_CHAT_ID_SIZE];
 
     Tox_Err_Group_State_Queries err;
@@ -353,7 +356,7 @@ static void init_groupchat_log(ToxWindow *self, Toxic *toxic, uint32_t groupnumb
         return;
     }
 
-    if (load_chat_history(ctx->log, self, c_config) != 0) {
+    if (load_chat_history(ctx->log, self, c_config, self_nick) != 0) {
         line_info_add(self, c_config, false, NULL, NULL, SYS_MSG, 0, 0, "Failed to load chat history.");
     }
 

--- a/src/line_info.h
+++ b/src/line_info.h
@@ -83,12 +83,21 @@ struct history {
 
 /* creates new line_info line and puts it in the queue.
  *
- * Returns the id of the new line.
+ * Returns the ID of the new line on success.
  * Returns -1 on failure.
  */
 __attribute__((format(printf, 9, 10)))
 int line_info_add(ToxWindow *self, const Client_Config *c_config, bool show_timestamp, const char *name1,
                   const char *name2, LINE_TYPE type, uint8_t bold, uint8_t colour, const char *msg, ...);
+
+/*
+ * Similar to line_info_add() but uses lines from history.
+ *
+ * Returns the ID of the new line on success.
+ * Returns -1 on failure.
+ */
+int line_info_load_history(ToxWindow *self, const Client_Config *c_config, const char *timestamp,
+                           const char *name, int colour, const char *message);
 
 /* Prints a section of history starting at line_start */
 void line_info_print(ToxWindow *self, const Client_Config *c_config);

--- a/src/log.h
+++ b/src/log.h
@@ -65,7 +65,7 @@ void log_disable(struct chatlog *log);
  * Return 0 on success or if log file doesn't exist.
  * Return -1 on failure.
  */
-int load_chat_history(struct chatlog *log, ToxWindow *self, const Client_Config *c_config);
+int load_chat_history(struct chatlog *log, ToxWindow *self, const Client_Config *c_config, const char *self_name);
 
 /* Renames chatlog file `src` to `dest`.
  *

--- a/src/message_queue.c
+++ b/src/message_queue.c
@@ -110,10 +110,10 @@ void cqueue_remove(ToxWindow *self, Toxic *toxic, uint32_t receipt)
         }
 
         if (log->log_on) {
-            char selfname[TOX_MAX_NAME_LENGTH];
+            char selfname[TOX_MAX_NAME_LENGTH + 1];
             tox_self_get_name(tox, (uint8_t *) selfname);
 
-            size_t len = tox_self_get_name_size(tox);
+            const size_t len = tox_self_get_name_size(tox);
             selfname[len] = 0;
 
             write_to_log(log, c_config, msg->message, selfname, msg->type == OUT_ACTION);

--- a/src/settings.c
+++ b/src/settings.c
@@ -662,7 +662,7 @@ int settings_load_main(Client_Config *s, const Run_Options *run_opts)
         if (config_setting_lookup_int(setting, ui_strings.time_format, &time)) {
             if (time == 12) {
                 snprintf(s->timestamp_format, sizeof(s->timestamp_format), "%s", "%I:%M %p");
-                snprintf(s->log_timestamp_format, sizeof(s->log_timestamp_format), "%s", "%Y/%m/%d [%I:%M:%S %p]");
+                snprintf(s->log_timestamp_format, sizeof(s->log_timestamp_format), "%s", "%Y/%m/%d [%I:%M %p]");
             }
         }
 

--- a/src/settings.h
+++ b/src/settings.h
@@ -143,7 +143,7 @@ enum settings_values {
 #define LINE_NORMAL  "-"
 #define LINE_SPECIAL ">"
 #define TIMESTAMP_DEFAULT      "%H:%M"
-#define LOG_TIMESTAMP_DEFAULT  "%Y/%m/%d [%H:%M:%S]"
+#define LOG_TIMESTAMP_DEFAULT  "%Y/%m/%d [%H:%M]"
 #define MPLEX_AWAY_NOTE "Away from keyboard, be back soon!"
 
 typedef struct Windows Windows;


### PR DESCRIPTION
This is only a partial implementation. We only colourize normal messages at present. In order to do other types of messages (actions, connection status, mod events etc.) we'll need to change the log format to give us more hints.

This commit also removes seconds from the default log timestamp for consistency with the UI default, and adds the missing config example field for custom log timestamp formats.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/toxic/332)
<!-- Reviewable:end -->
