### PR TITLE
fix: make sure realloc() called with a 0 value doesn't abort toxic

### DIFF
--- a/src/windows.c
+++ b/src/windows.c
@@ -884,7 +884,7 @@ void del_window(ToxWindow *w, Windows *windows, const Client_Config *c_config)
 
     ToxWindow **tmp_list = (ToxWindow **)realloc(windows->list, windows->count * sizeof(ToxWindow *));
 
-    if (tmp_list == NULL) {
+    if (tmp_list == NULL && windows->count != 0) {
         exit_toxic_err("realloc() failed in del_window()", FATALERR_MEMORY);
     }
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/toxic/337)
<!-- Reviewable:end -->
