### PR TITLE
cleanup: Remove unused macros from toxic.c

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
             -DAUDIO
             -DBOX_NOTIFY
             -DGAMES
-            -DPACKAGE_DATADIR='""'
+            -DPACKAGE_DATADIR='"."'
             -DPYTHON
             -DQRCODE
             -DSOUND_NOTIFY

--- a/src/main.c
+++ b/src/main.c
@@ -84,10 +84,6 @@
 #include "python_api.h"
 #endif
 
-#ifndef PACKAGE_DATADIR
-#define PACKAGE_DATADIR "."
-#endif
-
 #define DATANAME  "toxic_profile.tox"
 #define BLOCKNAME "toxic_blocklist"
 

--- a/src/toxic.c
+++ b/src/toxic.c
@@ -84,13 +84,6 @@
 #include "python_api.h"
 #endif
 
-#ifndef PACKAGE_DATADIR
-#define PACKAGE_DATADIR "."
-#endif
-
-#define DATANAME  "toxic_profile.tox"
-#define BLOCKNAME "toxic_blocklist"
-
 struct Winthread Winthread;
 
 static void queue_init_message(const char *msg, ...);


### PR DESCRIPTION
They are now in main.c.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/toxic/339)
<!-- Reviewable:end -->
