### PR TITLE
feat: re-colourize the rest of logs on load

### DIFF
--- a/src/chat.c
+++ b/src/chat.c
@@ -187,7 +187,7 @@ static void recv_message_helper(ToxWindow *self, const Toxic *toxic, const char 
     ChatContext *ctx = self->chatwin;
 
     line_info_add(self, c_config, true, nick, NULL, IN_MSG, 0, 0, "%s", msg);
-    write_to_log(ctx->log, c_config, msg, nick, false, LOG_HINT_NORMAL_I);
+    write_to_log(ctx->log, c_config, msg, nick, LOG_HINT_NORMAL_I);
 
     if (self->active_box != -1) {
         box_notify2(self, toxic, generic_message, NT_WNDALERT_1 | NT_NOFOCUS | c_config->bell_on_message,
@@ -204,7 +204,7 @@ static void recv_action_helper(ToxWindow *self, const Toxic *toxic,  const char 
     ChatContext *ctx = self->chatwin;
 
     line_info_add(self, c_config, true, nick, NULL, IN_ACTION, 0, 0, "%s", action);
-    write_to_log(ctx->log, c_config, action, nick, true, LOG_HINT_ACTION);
+    write_to_log(ctx->log, c_config, action, nick, LOG_HINT_ACTION);
 
     if (self->active_box != -1) {
         box_notify2(self, toxic, generic_message, NT_WNDALERT_1 | NT_NOFOCUS | c_config->bell_on_message,
@@ -274,7 +274,7 @@ static void chat_onConnectionChange(ToxWindow *self, Toxic *toxic, uint32_t num,
         if (c_config->show_connection_msg) {
             msg = "has come online";
             line_info_add(self, c_config, true, name, NULL, CONNECTION, 0, GREEN, "%s", msg);
-            write_to_log(ctx->log, c_config, msg, name, true, LOG_HINT_CONNECT);
+            write_to_log(ctx->log, c_config, msg, name, LOG_HINT_CONNECT);
         }
     } else if (connection_status == TOX_CONNECTION_NONE) {
         Friends.list[num].is_typing = false;
@@ -288,7 +288,7 @@ static void chat_onConnectionChange(ToxWindow *self, Toxic *toxic, uint32_t num,
         if (c_config->show_connection_msg) {
             msg = "has gone offline";
             line_info_add(self, c_config, true, name, NULL, DISCONNECTION, 0, RED, "%s", msg);
-            write_to_log(ctx->log, c_config, msg, name, true, LOG_HINT_DISCONNECT);
+            write_to_log(ctx->log, c_config, msg, name, LOG_HINT_DISCONNECT);
         }
     }
 }
@@ -1684,18 +1684,12 @@ static void chat_init_log(ToxWindow *self, Toxic *toxic, const char *self_nick)
     char myid[TOX_ADDRESS_SIZE];
     tox_self_get_address(tox, (uint8_t *) myid);
 
-    char self_name[TOX_MAX_NAME_LENGTH + 1];
-    tox_self_get_name(tox, (uint8_t *) self_name);
-
-    const size_t len = tox_self_get_name_size(tox);
-    self_name[len] = '\0';
-
     if (log_init(ctx->log, c_config, self_nick, myid, Friends.list[self->num].pub_key, LOG_TYPE_CHAT) != 0) {
         line_info_add(self, c_config, false, NULL, NULL, SYS_MSG, 0, 0, "Failed to initialize chat log.");
         return;
     }
 
-    if (load_chat_history(ctx->log, self, c_config, self_name) != 0) {
+    if (load_chat_history(ctx->log, self, c_config) != 0) {
         line_info_add(self, c_config, false, NULL, NULL, SYS_MSG, 0, 0, "Failed to load chat history.");
     }
 

--- a/src/conference_commands.c
+++ b/src/conference_commands.c
@@ -116,18 +116,11 @@ void cmd_conference_set_title(WINDOW *window, ToxWindow *self, Toxic *toxic, int
 
     conference_set_title(self, self->num, title, len);
 
-    char selfnick[TOX_MAX_NAME_LENGTH];
-    tox_self_get_name(tox, (uint8_t *) selfnick);
+    char tmp_event[MAX_STR_SIZE];
+    snprintf(tmp_event, sizeof(tmp_event), "-!- You set the conference title to: %s", title);
 
-    size_t sn_len = tox_self_get_name_size(tox);
-    selfnick[sn_len] = '\0';
-
-    line_info_add(self, c_config, true, selfnick, NULL, NAME_CHANGE, 0, 0, " set the conference title to: %s",
-                  title);
-
-    char tmp_event[MAX_STR_SIZE + 20];
-    snprintf(tmp_event, sizeof(tmp_event), "set title to %s", title);
-    write_to_log(self->chatwin->log, c_config, tmp_event, selfnick, true, LOG_HINT_TOPIC);
+    line_info_add(self, c_config, true, NULL, NULL, SYS_MSG, 1, MAGENTA, "%s", tmp_event);
+    write_to_log(self->chatwin->log, c_config, tmp_event, NULL, LOG_HINT_TOPIC);
 }
 
 #ifdef AUDIO

--- a/src/groupchat_commands.c
+++ b/src/groupchat_commands.c
@@ -971,11 +971,11 @@ void cmd_set_topic(WINDOW *window, ToxWindow *self, Toxic *toxic, int argc, char
     char self_nick[TOX_MAX_NAME_LENGTH + 1];
     get_group_self_nick_truncate(tox, self_nick, self->num);
 
-    line_info_add(self, c_config, true, NULL, NULL, SYS_MSG, 1, MAGENTA, "-!- You set the topic to: %s", topic);
-
     char tmp_event[MAX_STR_SIZE];
-    snprintf(tmp_event, sizeof(tmp_event), "set topic to %s", topic);
-    write_to_log(self->chatwin->log, c_config, tmp_event, self_nick, true, LOG_HINT_TOPIC);
+    snprintf(tmp_event, sizeof(tmp_event), "-!- You set the topic to: %s", topic);
+
+    line_info_add(self, c_config, true, NULL, NULL, SYS_MSG, 1, MAGENTA, "%s", tmp_event);
+    write_to_log(self->chatwin->log, c_config, tmp_event, NULL, LOG_HINT_TOPIC);
 }
 
 void cmd_unignore(WINDOW *window, ToxWindow *self, Toxic *toxic, int argc, char (*argv)[MAX_STR_SIZE])

--- a/src/line_info.h
+++ b/src/line_info.h
@@ -101,7 +101,7 @@ int line_info_add(ToxWindow *self, const Client_Config *c_config, bool show_time
  * Returns -1 on failure.
  */
 int line_info_load_history(ToxWindow *self, const Client_Config *c_config, const char *timestamp,
-                           const char *name, int colour, const char *message);
+                           const char *name, LINE_TYPE type, bool bold, int colour, const char *message);
 
 /* Prints a section of history starting at line_start */
 void line_info_print(ToxWindow *self, const Client_Config *c_config);

--- a/src/log.h
+++ b/src/log.h
@@ -67,14 +67,13 @@ int log_init(struct chatlog *log, const Client_Config *c_config, const char *nam
  * `log` is the log being written to.
  * `msg` is the message being written.
  * `name` is the name of the initiator of the message. If NULL it will be ignored.
- * `is_event` is true if the message is an event rather than a chat message.
  * `log_hint` indicates the type of message.
  *
  * Return 0 on success (or if the log is disabled).
  * Return -1 on failure.
  */
 int write_to_log(struct chatlog *log, const Client_Config *c_config, const char *msg, const char *name,
-                 bool is_event, Log_Hint log_hint);
+                 Log_Hint log_hint);
 
 /* Enables logging for specified log.
  *
@@ -96,7 +95,7 @@ void log_disable(struct chatlog *log);
  * Return 0 on success or if log file doesn't exist.
  * Return -1 on failure.
  */
-int load_chat_history(struct chatlog *log, ToxWindow *self, const Client_Config *c_config, const char *self_name);
+int load_chat_history(struct chatlog *log, ToxWindow *self, const Client_Config *c_config);
 
 /* Renames chatlog file `src` to `dest`.
  *

--- a/src/main.c
+++ b/src/main.c
@@ -1079,7 +1079,7 @@ static void parse_args(Toxic *toxic, Init_Queue *init_q, int argc, char *argv[])
                     exit_toxic_err(FATALERR_PROXY, "Proxy error");
                 }
 
-                long int port = strtol(argv[optind - 1], NULL, 10);
+                const long int port = strtol(argv[optind - 1], NULL, 10);
 
                 if (port <= 0 || port > MAX_PORT_RANGE) {
                     exit_toxic_err(FATALERR_PROXY, "Proxy error");

--- a/src/message_queue.c
+++ b/src/message_queue.c
@@ -116,7 +116,8 @@ void cqueue_remove(ToxWindow *self, Toxic *toxic, uint32_t receipt)
             const size_t len = tox_self_get_name_size(tox);
             selfname[len] = '\0';
 
-            write_to_log(log, c_config, msg->message, selfname, msg->type == OUT_ACTION, LOG_HINT_NORMAL_O);
+            write_to_log(log, c_config, msg->message, selfname,
+                         msg->type == OUT_MSG ? LOG_HINT_NORMAL_O : LOG_HINT_ACTION);
         }
 
         cqueue_mark_read(self, msg);

--- a/src/prompt.c
+++ b/src/prompt.c
@@ -257,7 +257,7 @@ static bool prompt_onKey(ToxWindow *self, Toxic *toxic, wint_t key, bool ltr)
         input_ret = true;
 
         if (ctx->len > 1 && ctx->line[0] == '/') {
-            int diff = -1;
+            int diff;
 
             if (wcsncmp(ctx->line, L"/avatar ", wcslen(L"/avatar ")) == 0) {
                 diff = dir_match(self, toxic, ctx->line, L"/avatar");
@@ -517,7 +517,7 @@ static void prompt_onConnectionChange(ToxWindow *self, Toxic *toxic, uint32_t fr
     if (connection_status != TOX_CONNECTION_NONE && Friends.list[friendnum].connection_status == TOX_CONNECTION_NONE) {
         msg = "has come online";
         line_info_add(self, c_config, true, nick, NULL, CONNECTION, 0, GREEN, "%s", msg);
-        write_to_log(ctx->log, c_config, msg, nick, true, LOG_HINT_CONNECT);
+        write_to_log(ctx->log, c_config, msg, nick, LOG_HINT_CONNECT);
 
         if (self->active_box != -1) {
             box_notify2(self, toxic, user_log_in, NT_WNDALERT_2 | NT_NOTIFWND | NT_RESTOL, self->active_box,
@@ -529,7 +529,7 @@ static void prompt_onConnectionChange(ToxWindow *self, Toxic *toxic, uint32_t fr
     } else if (connection_status == TOX_CONNECTION_NONE) {
         msg = "has gone offline";
         line_info_add(self, c_config, true, nick, NULL, DISCONNECTION, 0, RED, "%s", msg);
-        write_to_log(ctx->log, c_config, msg, nick, true, LOG_HINT_DISCONNECT);
+        write_to_log(ctx->log, c_config, msg, nick, LOG_HINT_DISCONNECT);
 
         if (self->active_box != -1) {
             box_notify2(self, toxic, user_log_out, NT_WNDALERT_2 | NT_NOTIFWND | NT_RESTOL, self->active_box,
@@ -570,10 +570,8 @@ static void prompt_onFriendRequest(ToxWindow *self, Toxic *toxic, const char *ke
     }
 
     const Client_Config *c_config = toxic->c_config;
-    ChatContext *ctx = self->chatwin;
 
     line_info_add(self, c_config, true, NULL, NULL, SYS_MSG, 0, 0, "Friend request with the message '%s'", data);
-    write_to_log(ctx->log, c_config, "Friend request with the message '%s'", "", true, LOG_HINT_SYSTEM);
 
     if (key_is_similar(key)) {
         line_info_add(self, c_config, false, NULL, NULL, SYS_MSG, 0, RED,


### PR DESCRIPTION
This isn't perfect but it's close enough for now.

Logs needing the `:` character for extracting nicks from logs is dealt with in https://github.com/TokTok/toxic/pull/348

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/toxic/342)
<!-- Reviewable:end -->
