### PR TITLE
fix: filter \t and \v escape sequences from inbound strings

### DIFF
--- a/src/misc_tools.c
+++ b/src/misc_tools.c
@@ -538,15 +538,18 @@ size_t get_group_self_nick_truncate(Tox *tox, char *buf, uint32_t groupnum)
     return len;
 }
 
-/* copies data to msg buffer, removing return characters.
-   returns length of msg, which will be no larger than size-1 */
 size_t copy_tox_str(char *msg, size_t size, const char *data, size_t length)
 {
     size_t j = 0;
 
     for (size_t i = 0; (i < length) && (j < size - 1); ++i) {
-        if (data[i] != '\r') {
-            msg[j] = data[i];
+        const char ch = data[i];
+
+        if (ch == '\t' || ch == '\v') {
+            msg[j] = ' ';
+            ++j;
+        } else if (ch != '\r') {
+            msg[j] = ch;
             ++j;
         }
     }

--- a/src/misc_tools.h
+++ b/src/misc_tools.h
@@ -208,8 +208,11 @@ size_t get_group_nick_truncate(Tox *tox, char *buf, uint32_t peer_id, uint32_t g
 /* same as get_group_nick_truncate() but for self. */
 size_t get_group_self_nick_truncate(Tox *tox, char *buf, uint32_t groupnum);
 
-/* copies data to msg buffer.
-   returns length of msg, which will be no larger than size-1 */
+/* Copies up to `size` bytes from the `data` string of length `length` to the `msg` buffer,
+ * replacing all \t and \v bytes with spaces, and removing all \r bytes.
+ *
+ * Returns the length of the resulting string in `msg`, which is guaranteed to be NUL-terminated.
+ */
 size_t copy_tox_str(char *msg, size_t size, const char *data, size_t length);
 
 /* returns index of the first instance of ch in s starting at idx.


### PR DESCRIPTION
These escape sequences mess with toxic's window scrolling and line formatting

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/toxic/343)
<!-- Reviewable:end -->
