### PR TITLE
refactor: Window ID's and window creation error handling

### DIFF
--- a/src/audio_call.c
+++ b/src/audio_call.c
@@ -424,7 +424,14 @@ void callback_recv_invite(Toxic *toxic, uint32_t friend_number)
     }
 
     if (Friends.list[friend_number].window_id == -1) {
-        Friends.list[friend_number].window_id = add_window(toxic, new_chat(toxic->tox, Friends.list[friend_number].num));
+        const int window_id = add_window(toxic, new_chat(toxic->tox, Friends.list[friend_number].num));
+
+        if (window_id < 0) {
+            fprintf(stderr, "Failed to create new chat window in callback_recv_invite()\n");
+            return;
+        }
+
+        Friends.list[friend_number].window_id = window_id;
     }
 
     const Call *call = &CallControl.calls[friend_number];

--- a/src/conference.h
+++ b/src/conference.h
@@ -61,7 +61,7 @@ typedef struct NameListEntry {
 
 typedef struct {
     uint32_t conferencenum;
-    int64_t window_id;
+    uint16_t window_id;
     bool active;
     uint8_t type;
     int side_pos;    /* current position of the sidebar - used for scrolling up and down */
@@ -90,7 +90,7 @@ typedef struct {
 /* Frees all Toxic associated data structures for a conference (does not call tox_conference_delete() ) */
 void free_conference(ToxWindow *self, Windows *windows, const Client_Config *c_config, uint32_t conferencenum);
 
-int64_t init_conference_win(Toxic *toxic, uint32_t conferencenum, uint8_t type, const char *title, size_t length);
+int init_conference_win(Toxic *toxic, uint32_t conferencenum, uint8_t type, const char *title, size_t length);
 
 /* destroys and re-creates conference window with or without the peerlist */
 void redraw_conference_win(ToxWindow *self);

--- a/src/friendlist.c
+++ b/src/friendlist.c
@@ -433,7 +433,14 @@ static void friendlist_onMessage(ToxWindow *self, Toxic *toxic, uint32_t num, To
         return;
     }
 
-    Friends.list[num].window_id = add_window(toxic, new_chat(tox, Friends.list[num].num));
+    const int window_id = add_window(toxic, new_chat(tox, Friends.list[num].num));
+
+    if (window_id < 0) {
+        fprintf(stderr, "Failed to create new chat window in friendlist_onMessage\n");
+        return;
+    }
+
+    Friends.list[num].window_id = window_id;
 }
 
 static void friendlist_onConnectionChange(ToxWindow *self, Toxic *toxic, uint32_t num, Tox_Connection connection_status)
@@ -657,7 +664,14 @@ static void friendlist_onGameInvite(ToxWindow *self, Toxic *toxic, uint32_t frie
         return;
     }
 
-    Friends.list[friend_number].window_id = add_window(toxic, new_chat(tox, Friends.list[friend_number].num));
+    const int window_id = add_window(toxic, new_chat(tox, Friends.list[friend_number].num));
+
+    if (window_id < 0) {
+        fprintf(stderr, "Failed to create new chat window in friendlist_onGameInvite\n");
+        return;
+    }
+
+    Friends.list[friend_number].window_id = window_id;
 }
 
 #endif // GAMES
@@ -680,7 +694,14 @@ static void friendlist_onFileRecv(ToxWindow *self, Toxic *toxic, uint32_t num, u
         return;
     }
 
-    Friends.list[num].window_id = add_window(toxic, new_chat(tox, Friends.list[num].num));
+    const int window_id = add_window(toxic, new_chat(tox, Friends.list[num].num));
+
+    if (window_id < 0) {
+        fprintf(stderr, "Failed to create new chat window in friendlist_onFileRecv\n");
+        return;
+    }
+
+    Friends.list[num].window_id = window_id;
 }
 
 static void friendlist_onConferenceInvite(ToxWindow *self, Toxic *toxic, int32_t num, uint8_t type,
@@ -706,7 +727,14 @@ static void friendlist_onConferenceInvite(ToxWindow *self, Toxic *toxic, int32_t
         return;
     }
 
-    Friends.list[num].window_id = add_window(toxic, new_chat(tox, Friends.list[num].num));
+    const int window_id = add_window(toxic, new_chat(tox, Friends.list[num].num));
+
+    if (window_id < 0) {
+        fprintf(stderr, "Failed to create new chat window in friendlist_onConferenceInvite\n");
+        return;
+    }
+
+    Friends.list[num].window_id = window_id;
 }
 
 static void friendlist_onGroupInvite(ToxWindow *self, Toxic *toxic, uint32_t num, const char *data, size_t length,
@@ -730,7 +758,14 @@ static void friendlist_onGroupInvite(ToxWindow *self, Toxic *toxic, uint32_t num
         return;
     }
 
-    Friends.list[num].window_id = add_window(toxic, new_chat(tox, Friends.list[num].num));
+    const int window_id = add_window(toxic, new_chat(tox, Friends.list[num].num));
+
+    if (window_id < 0) {
+        fprintf(stderr, "Failed to create new chat window in friendlist_onGroupInvite\n");
+        return;
+    }
+
+    Friends.list[num].window_id = window_id;
 }
 
 /* move friendlist/blocklist cursor up and down */
@@ -1015,7 +1050,14 @@ static bool friendlist_onKey(ToxWindow *self, Toxic *toxic, wint_t key, bool ltr
 
             /* Jump to chat window if already open */
             if (Friends.list[f].window_id < 0) {
-                Friends.list[f].window_id = add_window(toxic, new_chat(tox, Friends.list[f].num));
+                const int window_id = add_window(toxic, new_chat(tox, Friends.list[f].num));
+
+                if (window_id < 0) {
+                    fprintf(stderr, "Failed to create new chat window in friendlist_onKey\n");
+                    return true;
+                }
+
+                Friends.list[f].window_id = window_id;
             }
 
             set_active_window_by_id(toxic->windows, Friends.list[f].window_id);
@@ -1408,8 +1450,15 @@ static void friendlist_onAV(ToxWindow *self, Toxic *toxic, uint32_t friend_numbe
     }
 
     if (state != TOXAV_FRIEND_CALL_STATE_FINISHED) {
-        Friends.list[friend_number].window_id = add_window(toxic, new_chat(tox, Friends.list[friend_number].num));
-        set_active_window_by_id(toxic->windows, Friends.list[friend_number].window_id);
+        const int window_id = add_window(toxic, new_chat(tox, Friends.list[friend_number].num));
+
+        if (window_id < 0) {
+            fprintf(stderr, "Failed to create new chat window in friendlist_onAV");
+            return;
+        }
+
+        Friends.list[friend_number].window_id = window_id;
+        set_active_window_by_id(toxic->windows, window_id);
     }
 }
 #endif /* AUDIO */

--- a/src/friendlist.h
+++ b/src/friendlist.h
@@ -85,7 +85,7 @@ typedef struct {
     size_t statusmsg_len;
     char pub_key[TOX_PUBLIC_KEY_SIZE];
     uint32_t num;
-    int64_t window_id;
+    int window_id;
     bool active;
     Tox_Connection connection_status;
     bool is_typing;

--- a/src/game_base.c
+++ b/src/game_base.c
@@ -274,7 +274,7 @@ int game_initialize(const ToxWindow *parent, Toxic *toxic, GameType type, uint32
 
     GameData *game = self->game;
 
-    const int64_t window_id = add_window(toxic, self);
+    const int window_id = add_window(toxic, self);
 
     if (window_id < 0) {
         free(game);

--- a/src/game_base.h
+++ b/src/game_base.h
@@ -151,7 +151,7 @@ struct GameData {
     int        parent_max_x; // max dimensions of parent window
     int        parent_max_y;
 
-    int64_t    window_id;
+    uint16_t   window_id;
     WINDOW     *window;
 
     Toxic      *toxic;  // must be locked with Winthread mutex

--- a/src/global_commands.c
+++ b/src/global_commands.c
@@ -523,7 +523,7 @@ void cmd_conference(WINDOW *window, ToxWindow *self, Toxic *toxic, int argc, cha
 #endif
     }
 
-    if (init_conference_win(toxic, conferencenum, type, NULL, 0) == -1) {
+    if (init_conference_win(toxic, conferencenum, type, NULL, 0) < 0) {
         line_info_add(self, c_config, false, NULL, NULL, SYS_MSG, 0, 0, "Conference window failed to initialize.");
         tox_conference_delete(tox, conferencenum, NULL);
         return;

--- a/src/groupchats.h
+++ b/src/groupchats.h
@@ -67,7 +67,7 @@ typedef struct {
     bool       active;
     uint64_t   time_connected;    /* The time we successfully connected to the group */
 
-    int64_t    window_id;
+    uint16_t   window_id;
     int        side_pos;     /* current position of the sidebar - used for scrolling up and down */
 } GroupChat;
 

--- a/src/log.c
+++ b/src/log.c
@@ -377,7 +377,7 @@ int load_chat_history(struct chatlog *log, ToxWindow *self, const Client_Config 
  * Return -1 on failure.
  */
 int rename_logfile(Windows *windows, const Client_Config *c_config, const char *src, const char *dest,
-                   const char *selfkey, const char *otherkey, uint32_t window_id)
+                   const char *selfkey, const char *otherkey, uint16_t window_id)
 {
     ToxWindow *toxwin = get_window_pointer_by_id(windows, window_id);
     struct chatlog *log = NULL;

--- a/src/log.h
+++ b/src/log.h
@@ -98,6 +98,6 @@ int load_chat_history(struct chatlog *log, ToxWindow *self, const Client_Config 
  * Return -1 on failure.
  */
 int rename_logfile(Windows *windows, const Client_Config *c_config, const char *src, const char *dest,
-                   const char *selfkey, const char *otherkey, uint32_t window_id);
+                   const char *selfkey, const char *otherkey, uint16_t window_id);
 
 #endif /* LOG_H */

--- a/src/main.c
+++ b/src/main.c
@@ -307,9 +307,9 @@ static void load_conferences(Toxic *toxic)
 
         title[length] = 0;
 
-        const int64_t win_id = init_conference_win(toxic, conferencenum, type, (const char *) title, length);
+        const int win_id = init_conference_win(toxic, conferencenum, type, (const char *) title, length);
 
-        if (win_id == -1) {
+        if (win_id < 0) {
             tox_conference_delete(tox, conferencenum, NULL);
             continue;
         }

--- a/src/toxic.h
+++ b/src/toxic.h
@@ -71,7 +71,6 @@ typedef struct Windows {
     ToxWindow  **list;
     uint16_t   count;
     uint16_t   active_index;
-    uint32_t   next_id;
 } Windows;
 
 typedef struct Toxic {

--- a/src/windows.c
+++ b/src/windows.c
@@ -761,7 +761,7 @@ void on_group_voice_state(Tox *tox, uint32_t groupnumber, Tox_Group_Voice_State 
  * Returns the windows list index of the window associated with `id`.
  * Returns -1 if `id` is not found.
  */
-static int get_window_index(Windows *windows, uint32_t id)
+static int get_window_index(Windows *windows, uint16_t id)
 {
     for (uint16_t i = 0; i < windows->count; ++i) {
         if (windows->list[i]->id == id) {
@@ -772,16 +772,23 @@ static int get_window_index(Windows *windows, uint32_t id)
     return -1;
 }
 
-static uint32_t get_new_window_id(Windows *windows)
+static uint16_t get_new_window_id(Windows *windows)
 {
-    const uint32_t new_id = windows->next_id;
-    ++windows->next_id;
+    uint16_t new_id = 0;
+
+    for (uint16_t i = 0; i < UINT16_MAX; ++i) {
+        if (get_window_pointer_by_id(windows, i) == NULL) {
+            new_id = i;
+            break;
+        }
+    }
+
     return new_id;
 }
 
 /* CALLBACKS END */
 
-int64_t add_window(Toxic *toxic, ToxWindow *w)
+int add_window(Toxic *toxic, ToxWindow *w)
 {
     if (w == NULL || LINES < 2) {
         fprintf(stderr, "Failed to add window.\n");
@@ -835,7 +842,7 @@ void set_active_window_by_type(Windows *windows, Window_Type type)
     fprintf(stderr, "Warning: attemping to set active window with no active type: %d\n", type);
 }
 
-void set_active_window_by_id(Windows *windows, uint32_t id)
+void set_active_window_by_id(Windows *windows, uint16_t id)
 {
     const int idx = get_window_index(windows, id);
 
@@ -1357,7 +1364,7 @@ void refresh_inactive_windows(Windows *windows, const Client_Config *c_config)
 /* Returns a pointer to the ToxWindow associated with `id`.
  * Returns NULL if no ToxWindow exists.
  */
-ToxWindow *get_window_pointer_by_id(Windows *windows, uint32_t id)
+ToxWindow *get_window_pointer_by_id(Windows *windows, uint16_t id)
 {
     for (uint16_t i = 0; i < windows->count; ++i) {
         ToxWindow *w = windows->list[i];

--- a/src/windows.h
+++ b/src/windows.h
@@ -226,7 +226,7 @@ struct ToxWindow {
     char name[TOXIC_MAX_NAME_LENGTH + 1];
     int colour;  /* The ncurses colour pair of the window name */
     uint32_t num;    /* corresponds to friendnumber in chat windows */
-    uint32_t id; /* a unique and permanent identifier for this window */
+    uint16_t id; /* a unique and permanent identifier for this window */
     bool scroll_pause; /* true if this window is not scrolled to the bottom */
     unsigned int pending_messages;  /* # of new messages in this window since the last time it was focused */
     int x;
@@ -323,19 +323,26 @@ struct Help {
 
 void init_windows(Toxic *toxic);
 void draw_active_window(Toxic *toxic);
-int64_t add_window(Toxic *toxic, ToxWindow *w);
 void del_window(ToxWindow *w, Windows *windows, const Client_Config *c_config);
 void kill_all_windows(Toxic *toxic);    /* should only be called on shutdown */
 void on_window_resize(Windows *windows);
 void force_refresh(WINDOW *w);
-ToxWindow *get_window_pointer_by_id(Windows *windows, uint32_t id);
+ToxWindow *get_window_pointer_by_id(Windows *windows, uint16_t id);
 ToxWindow *get_active_window(const Windows *windows);
 void draw_window_bar(ToxWindow *self, Windows *windows);
 
 /*
+ * Initializes window `w` and adds it to the windows list.
+ *
+ * Returns the window's unique ID on success.
+ * Returns -1 on failure.
+ */
+int add_window(Toxic *toxic, ToxWindow *w);
+
+/*
  * Sets the active window to the window associated with `id`.
  */
-void set_active_window_by_id(Windows *windows, uint32_t id);
+void set_active_window_by_id(Windows *windows, uint16_t id);
 
 /*
  * Sets the active window to the first found window of window type `type`.


### PR DESCRIPTION
We now use 16-bit ID's for windows and re-use previously discarded ID's instead of using an incrementer. We also now do proper error handling on window creation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/toxic/344)
<!-- Reviewable:end -->
