### PR TITLE
refactor: Make filter_str() less error-prone

### DIFF
--- a/src/chat.c
+++ b/src/chat.c
@@ -1578,9 +1578,9 @@ static void chat_onDraw(ToxWindow *self, Toxic *toxic)
         tox_friend_get_status_message(toxic->tox, self->num, (uint8_t *) statusmsg, NULL);
         const size_t s_len = tox_friend_get_status_message_size(toxic->tox, self->num, NULL);
 
-        filter_str(statusmsg, s_len);
+        filter_string(statusmsg);
         snprintf(statusbar->statusmsg, sizeof(statusbar->statusmsg), "%s", statusmsg);
-        statusbar->statusmsg_len = strlen(statusbar->statusmsg);
+        statusbar->statusmsg_len = s_len;
 
         pthread_mutex_unlock(&Winthread.lock);
     }
@@ -1738,7 +1738,7 @@ static void chat_onInit(ToxWindow *self, Toxic *toxic)
         char statusmsg[TOX_MAX_STATUS_MESSAGE_LENGTH + 1] = {0};
         tox_friend_get_status_message(tox, self->num, (uint8_t *) statusmsg, NULL);
         statusmsg[s_len] = '\0';
-        filter_str(statusmsg, s_len);
+        filter_string(statusmsg);
         snprintf(statusbar->statusmsg, sizeof(statusbar->statusmsg), "%s", statusmsg);
     }
 

--- a/src/friendlist.c
+++ b/src/friendlist.c
@@ -1242,7 +1242,7 @@ static void friendlist_onDraw(ToxWindow *self, Toxic *toxic)
 
                     statusmsg[s_len] = '\0';
 
-                    filter_str(statusmsg, s_len);
+                    filter_string(statusmsg);
 
                     pthread_mutex_lock(&Winthread.lock);
                     snprintf(Friends.list[f].statusmsg, sizeof(Friends.list[f].statusmsg), "%s", statusmsg);
@@ -1730,7 +1730,7 @@ bool friend_config_set_alias(const char *public_key, const char *alias, uint16_t
 
     char tmp[TOXIC_MAX_NAME_LENGTH + 1];
     const uint16_t tmp_len = copy_tox_str(tmp, sizeof(tmp), alias, length);
-    filter_str(tmp, tmp_len);
+    filter_string(tmp);
 
     if (tmp_len == 0 || tmp_len > TOXIC_MAX_NAME_LENGTH) {
         return false;

--- a/src/groupchats.c
+++ b/src/groupchats.c
@@ -441,7 +441,7 @@ void groupchat_update_statusbar_topic(ToxWindow *self, const Tox *tox)
 
     tox_group_get_topic(tox, self->num, (uint8_t *)topic, NULL);
     topic[t_len] = '\0';
-    filter_str(topic, t_len);
+    filter_string(topic);
     snprintf(statusbar->topic, sizeof(statusbar->topic), "%s", topic);
     statusbar->topic_len = strlen(statusbar->topic);
 }

--- a/src/misc_tools.c
+++ b/src/misc_tools.c
@@ -340,7 +340,7 @@ bool valid_nick(const char *nick)
         return false;
     }
 
-    for (size_t i = 0; nick[i]; ++i) {
+    for (size_t i = 0; nick[i] != '\0'; ++i) {
         char ch = nick[i];
 
         if ((ch == ' ' && nick[i + 1] == ' ') || !is_valid_char(ch)) {
@@ -351,13 +351,12 @@ bool valid_nick(const char *nick)
     return true;
 }
 
-/* Converts all newline/tab chars to spaces (use for strings that should be contained to a single line) */
-void filter_str(char *str, size_t len)
+void filter_string(char *str)
 {
-    for (size_t i = 0; i < len; ++i) {
-        char ch = str[i];
+    for (size_t i = 0; str[i] != '\0'; ++i) {
+        const char ch = str[i];
 
-        if (!is_valid_char(ch) || str[i] == '\0') {
+        if (!is_valid_char(ch)) {
             str[i] = ' ';
         }
     }
@@ -450,7 +449,7 @@ size_t get_nick_truncate(Tox *tox, char *buf, uint16_t buf_size, uint32_t friend
 
     len = MIN(len, buf_size - 1);
     buf[len] = '\0';
-    filter_str(buf, len);
+    filter_string(buf);
 
     return len;
 
@@ -475,7 +474,7 @@ int get_conference_nick_truncate(Tox *tox, char *buf, uint32_t peernum, uint32_t
 
     len = MIN(len, TOXIC_MAX_NAME_LENGTH - 1);
     buf[len] = '\0';
-    filter_str(buf, len);
+    filter_string(buf);
     return len;
 
 on_error:
@@ -507,7 +506,7 @@ size_t get_group_nick_truncate(Tox *tox, char *buf, uint32_t peer_id, uint32_t g
     len = MIN(len, TOXIC_MAX_NAME_LENGTH - 1);
     buf[len] = '\0';
 
-    filter_str(buf, len);
+    filter_string(buf);
 
     return len;
 }
@@ -531,9 +530,9 @@ size_t get_group_self_nick_truncate(Tox *tox, char *buf, uint32_t groupnum)
     }
 
     len = MIN(len, TOXIC_MAX_NAME_LENGTH - 1);
-    buf[len] = 0;
+    buf[len] = '\0';
 
-    filter_str(buf, len);
+    filter_string(buf);
 
     return len;
 }

--- a/src/misc_tools.h
+++ b/src/misc_tools.h
@@ -171,7 +171,7 @@ bool valid_nick(const char *nick);
 /* Converts all newline/tab chars to spaces
  * (use for strings that should be contained to a single line)
  */
-void filter_str(char *str, size_t len);
+void filter_string(char *str);
 
 /* gets base file name from path or original file name if no path is supplied */
 size_t get_file_name(char *namebuf, size_t bufsize, const char *pathname);

--- a/src/windows.c
+++ b/src/windows.c
@@ -135,7 +135,7 @@ void on_friend_name(Tox *tox, uint32_t friendnumber, const uint8_t *string, size
 
     char nick[TOXIC_MAX_NAME_LENGTH + 1];
     length = copy_tox_str(nick, sizeof(nick), (const char *) string, length);
-    filter_str(nick, length);
+    filter_string(nick);
 
     for (uint16_t i = 0; i < windows->count; ++i) {
         ToxWindow *w = windows->list[i];
@@ -158,7 +158,7 @@ void on_friend_status_message(Tox *tox, uint32_t friendnumber, const uint8_t *st
 
     char msg[TOX_MAX_STATUS_MESSAGE_LENGTH + 1];
     length = copy_tox_str(msg, sizeof(msg), (const char *) string, length);
-    filter_str(msg, length);
+    filter_string(msg);
 
     for (uint16_t i = 0; i < windows->count; ++i) {
         ToxWindow *w = windows->list[i];
@@ -265,7 +265,7 @@ void on_conference_peer_name(Tox *tox, uint32_t conferencenumber, uint32_t peern
 
     char nick[TOXIC_MAX_NAME_LENGTH + 1];
     length = copy_tox_str(nick, sizeof(nick), (const char *) name, length);
-    filter_str(nick, length);
+    filter_string(nick);
 
     for (uint16_t i = 0; i < windows->count; ++i) {
         ToxWindow *w = windows->list[i];
@@ -680,7 +680,7 @@ void on_group_nick_change(Tox *tox, uint32_t groupnumber, uint32_t peer_id, cons
 
     char name[TOXIC_MAX_NAME_LENGTH + 1];
     length = copy_tox_str(name, sizeof(name), (const char *) newname, length);
-    filter_str(name, length);
+    filter_string(name);
 
     for (uint16_t i = 0; i < windows->count; ++i) {
         ToxWindow *w = windows->list[i];


### PR DESCRIPTION
Passing the string length to this function instead of just relying on the nul-terminator is pointless and only leaves room for errors. Also renamed str -> string.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/toxic/345)
<!-- Reviewable:end -->
