### PR TITLE
refactor: Make some fatal memory errors non-fatal

### DIFF
--- a/src/audio_call.h
+++ b/src/audio_call.h
@@ -102,7 +102,13 @@ bool init_call(Call *call);
 void place_call(ToxWindow *self, Toxic *toxic);
 void stop_current_call(ToxWindow *self, Toxic *toxic);
 
-void init_friend_AV(uint32_t index);
+/*
+ * Initializes the call structure for a given friend. Called when a friend is added
+ * to the friends list. Index must be equivalent to the friend's friendlist index.
+ *
+ * Returns true on success.
+ */
+bool init_friend_AV(uint32_t index);
 void del_friend_AV(uint32_t index);
 
 #endif /* AUDIO_CALL_H */

--- a/src/autocomplete.c
+++ b/src/autocomplete.c
@@ -139,7 +139,7 @@ static int complete_line_helper(ToxWindow *self, Toxic *toxic, const char *const
     char *sub = calloc(1, strlen(ubuf) + 1);
 
     if (sub == NULL) {
-        exit_toxic_err(FATALERR_MEMORY, "failed in complete_line_helper");
+        return -1;
     }
 
     if (!s && !dir_search) {

--- a/src/avatars.c
+++ b/src/avatars.c
@@ -152,13 +152,16 @@ int avatar_set(Tox *tox, const char *path, size_t path_len)
 
     fclose(fp);
 
-    off_t size = file_size(path);
+    const off_t size = file_size(path);
 
     if (size == 0 || size > MAX_AVATAR_FILE_SIZE) {
         return -1;
     }
 
-    get_file_name(Avatar.name, sizeof(Avatar.name), path);
+    if (get_file_name(Avatar.name, sizeof(Avatar.name), path) < 0) {
+        return -1;
+    }
+
     Avatar.name_len = strlen(Avatar.name);
     snprintf(Avatar.path, sizeof(Avatar.path), "%s", path);
     Avatar.path_len = path_len;

--- a/src/chat_commands.c
+++ b/src/chat_commands.c
@@ -94,7 +94,7 @@ void cmd_cancelfile(WINDOW *window, ToxWindow *self, Toxic *toxic, int argc, cha
 
     char msg[MAX_STR_SIZE];
     const char *inoutstr = argv[1];
-    long int idx = strtol(argv[2], NULL, 10);
+    const long int idx = strtol(argv[2], NULL, 10);
 
     if ((idx == 0 && strcmp(argv[2], "0")) || idx >= MAX_FILES || idx < 0) {
         line_info_add(self, c_config, false, NULL, NULL, SYS_MSG, 0, 0, "Invalid file ID.");
@@ -149,7 +149,7 @@ void cmd_conference_invite(WINDOW *window, ToxWindow *self, Toxic *toxic, int ar
         return;
     }
 
-    long int conferencenum = strtol(argv[1], NULL, 10);
+    const long int conferencenum = strtol(argv[1], NULL, 10);
 
     if ((conferencenum == 0 && strcmp(argv[1], "0")) || conferencenum < 0 || conferencenum == LONG_MAX) {
         line_info_add(self, c_config, false, NULL, NULL, SYS_MSG, 0, 0, "Invalid conference number.");
@@ -182,8 +182,8 @@ void cmd_conference_join(WINDOW *window, ToxWindow *self, Toxic *toxic, int argc
     const Client_Config *c_config = toxic->c_config;
 
     const char *conferencekey = Friends.list[self->num].conference_invite.key;
-    uint16_t length = Friends.list[self->num].conference_invite.length;
-    uint8_t type = Friends.list[self->num].conference_invite.type;
+    const uint16_t length = Friends.list[self->num].conference_invite.length;
+    const uint8_t type = Friends.list[self->num].conference_invite.type;
 
     if (!Friends.list[self->num].conference_invite.pending) {
         line_info_add(self, c_config, false, NULL, NULL, SYS_MSG, 0, 0, "No pending conference invite.");
@@ -273,9 +273,9 @@ void cmd_group_accept(WINDOW *window, ToxWindow *self, Toxic *toxic, int argc, c
     self_nick[nick_len] = '\0';
 
     Tox_Err_Group_Invite_Accept err;
-    uint32_t groupnumber = tox_group_invite_accept(tox, self->num, Friends.list[self->num].group_invite.data,
-                           Friends.list[self->num].group_invite.length, (const uint8_t *) self_nick, nick_len,
-                           (const uint8_t *) passwd, passwd_len, &err);
+    const uint32_t groupnumber = tox_group_invite_accept(tox, self->num, Friends.list[self->num].group_invite.data,
+                                 Friends.list[self->num].group_invite.length, (const uint8_t *) self_nick, nick_len,
+                                 (const uint8_t *) passwd, passwd_len, &err);
 
     if (err != TOX_ERR_GROUP_INVITE_ACCEPT_OK) {
         line_info_add(self, c_config, false, NULL, NULL, SYS_MSG, 0, 0, "Failed to join group (error %d).", err);
@@ -303,7 +303,7 @@ void cmd_group_invite(WINDOW *window, ToxWindow *self, Toxic *toxic, int argc, c
         return;
     }
 
-    int groupnumber = atoi(argv[1]);
+    const int groupnumber = atoi(argv[1]);
 
     if (groupnumber == 0 && strcmp(argv[1], "0")) {    /* atoi returns 0 value on invalid input */
         line_info_add(self, c_config, false, NULL, NULL, SYS_MSG, 0, 0, "Invalid group number.");
@@ -339,9 +339,9 @@ void cmd_game_join(WINDOW *window, ToxWindow *self, Toxic *toxic, int argc, char
     }
 
     GameType type = Friends.list[self->num].game_invite.type;
-    uint32_t id = Friends.list[self->num].game_invite.id;
+    const uint32_t id = Friends.list[self->num].game_invite.id;
     uint8_t *data = Friends.list[self->num].game_invite.data;
-    size_t length = Friends.list[self->num].game_invite.data_length;
+    const size_t length = Friends.list[self->num].game_invite.data_length;
 
     const int ret = game_initialize(self, toxic, type, id, data, length, false);
 
@@ -389,7 +389,7 @@ void cmd_savefile(WINDOW *window, ToxWindow *self, Toxic *toxic, int argc, char 
         return;
     }
 
-    long int idx = strtol(argv[1], NULL, 10);
+    const long int idx = strtol(argv[1], NULL, 10);
 
     if ((idx == 0 && strcmp(argv[1], "0")) || idx < 0 || idx >= MAX_FILES) {
         line_info_add(self, c_config, false, NULL, NULL, SYS_MSG, 0, 0, "No pending file transfers with ID %ld", idx);
@@ -480,7 +480,7 @@ void cmd_sendfile(WINDOW *window, ToxWindow *self, Toxic *toxic, int argc, char 
 
     char path[MAX_STR_SIZE];
     snprintf(path, sizeof(path), "%s", argv[1]);
-    int path_len = strlen(path);
+    const int path_len = strlen(path);
 
     if (path_len >= MAX_STR_SIZE) {
         line_info_add(self, c_config, false, NULL, NULL, SYS_MSG, 0, 0, "File path exceeds character limit.");
@@ -494,7 +494,7 @@ void cmd_sendfile(WINDOW *window, ToxWindow *self, Toxic *toxic, int argc, char 
         return;
     }
 
-    off_t filesize = file_size(path);
+    const off_t filesize = file_size(path);
 
     if (filesize <= 0) {
         line_info_add(self, c_config, false, NULL, NULL, SYS_MSG, 0, 0, "Invalid file.");
@@ -503,11 +503,17 @@ void cmd_sendfile(WINDOW *window, ToxWindow *self, Toxic *toxic, int argc, char 
     }
 
     char file_name[TOX_MAX_FILENAME_LENGTH];
-    size_t namelen = get_file_name(file_name, sizeof(file_name), path);
+    const int namelen = get_file_name(file_name, sizeof(file_name), path);
+
+    if (namelen < 0) {
+        line_info_add(self, c_config, false, NULL, NULL, SYS_MSG, 0, 0, "Failed to fetch file name (OOM)");
+        fclose(file_to_send);
+        return;
+    }
 
     Tox_Err_File_Send err;
-    uint32_t filenum = tox_file_send(tox, self->num, TOX_FILE_KIND_DATA, (uint64_t) filesize, NULL,
-                                     (uint8_t *) file_name, namelen, &err);
+    const uint32_t filenum = tox_file_send(tox, self->num, TOX_FILE_KIND_DATA, (uint64_t) filesize, NULL,
+                                           (uint8_t *) file_name, namelen, &err);
 
     if (err != TOX_ERR_FILE_SEND_OK) {
         goto on_send_error;
@@ -543,7 +549,7 @@ on_send_error:
         }
 
         case TOX_ERR_FILE_SEND_FRIEND_NOT_CONNECTED: {
-            int queue_idx = file_send_queue_add(self->num, path, path_len);
+            const int queue_idx = file_send_queue_add(self->num, path, path_len);
 
             char msg[MAX_STR_SIZE];
 

--- a/src/configdir.c
+++ b/src/configdir.c
@@ -120,10 +120,16 @@ int create_user_config_dirs(char *path)
     }
 
     char *fullpath = malloc(strlen(path) + strlen(CONFIGDIR) + 1);
+
+    if (fullpath == NULL) {
+        return -1;
+    }
+
     char *logpath = malloc(strlen(path) + strlen(LOGDIR) + 1);
 
-    if (fullpath == NULL || logpath == NULL) {
-        exit_toxic_err(FATALERR_MEMORY, "failed in load_data_structures");
+    if (logpath == NULL) {
+        free(fullpath);
+        return -1;
     }
 
     strcpy(fullpath, path);

--- a/src/execute.c
+++ b/src/execute.c
@@ -224,7 +224,7 @@ static int parse_command(const char *input, char (*args)[MAX_STR_SIZE])
     char *cmd = strdup(input);
 
     if (cmd == NULL) {
-        exit_toxic_err(FATALERR_MEMORY, "failed in parse_command");
+        return -1;
     }
 
     int num_args = 0;
@@ -273,9 +273,10 @@ void execute(WINDOW *w, ToxWindow *self, Toxic *toxic, const char *input, int mo
     }
 
     char args[MAX_NUM_ARGS][MAX_STR_SIZE];
-    int num_args = parse_command(input, args);
+    const int num_args = parse_command(input, args);
 
     if (num_args <= 0) {
+        fprintf(stderr, "Warning: parse_command(%s, %d) failed in execute()\n", input, mode);
         return;
     }
 

--- a/src/friendlist.c
+++ b/src/friendlist.c
@@ -597,7 +597,11 @@ void friendlist_onFriendAdded(ToxWindow *self, Toxic *toxic, uint32_t num, bool 
         }
 
 #ifdef AUDIO
-        init_friend_AV(i);
+
+        if (!init_friend_AV(i)) {
+            fprintf(stderr, "Failed to init AV for friend %u\n", i);
+        }
+
 #endif
 
         return;
@@ -635,7 +639,11 @@ static void friendlist_add_blocked(const Client_Config *c_config, uint32_t fnum,
         sort_friendlist_index();
 
 #ifdef AUDIO
-        init_friend_AV(i);
+
+        if (!init_friend_AV(i)) {
+            fprintf(stderr, "Failed to init AV for friend %d\n", i);
+        }
+
 #endif
         return;
     }

--- a/src/global_commands.c
+++ b/src/global_commands.c
@@ -254,7 +254,11 @@ void cmd_avatar(WINDOW *window, ToxWindow *self, Toxic *toxic, int argc, char (*
 
     path[len] = '\0';
     char filename[MAX_STR_SIZE];
-    get_file_name(filename, sizeof(filename), path);
+
+    if (get_file_name(filename, sizeof(filename), path) < 0) {
+        line_info_add(self, c_config, false, NULL, NULL, SYS_MSG, 0, 0, "Failed to fetch file name (OOM)");
+        return;
+    }
 
     if (avatar_set(tox, path, len) == -1) {
         line_info_add(self, c_config, false, NULL, NULL, SYS_MSG, 0, 0,

--- a/src/line_info.c
+++ b/src/line_info.c
@@ -45,7 +45,7 @@ void line_info_init(struct history *hst)
     hst->line_root = calloc(1, sizeof(struct line_info));
 
     if (hst->line_root == NULL) {
-        exit_toxic_err(FATALERR_MEMORY, "failed in line_info_init");
+        exit_toxic_err(FATALERR_MEMORY, "calloc() failed in line_info_init()");
     }
 
     hst->line_start = hst->line_root;

--- a/src/main.c
+++ b/src/main.c
@@ -1165,14 +1165,14 @@ static void init_default_data_files(Client_Data *client_data)
         client_data->block_path = strdup(BLOCKNAME);
 
         if (client_data->data_path == NULL || client_data->block_path == NULL) {
-            exit_toxic_err(FATALERR_MEMORY, "failed in init_default_data_files()");
+            exit_toxic_err(FATALERR_MEMORY, "strdup() failed in init_default_data_files()");
         }
     } else {
         client_data->data_path = malloc(strlen(user_config_dir) + strlen(CONFIGDIR) + strlen(DATANAME) + 1);
         client_data->block_path = malloc(strlen(user_config_dir) + strlen(CONFIGDIR) + strlen(BLOCKNAME) + 1);
 
         if (client_data->data_path == NULL || client_data->block_path == NULL) {
-            exit_toxic_err(FATALERR_MEMORY, "failed in init_default_data_files()");
+            exit_toxic_err(FATALERR_MEMORY, "malloc() failed in init_default_data_files()");
         }
 
         strcpy(client_data->data_path, user_config_dir);

--- a/src/misc_tools.c
+++ b/src/misc_tools.c
@@ -357,26 +357,25 @@ void filter_string(char *str, size_t len, bool is_nick)
     }
 }
 
-/* gets base file name from path or original file name if no path is supplied.
- * Returns the file name length
- */
-size_t get_file_name(char *namebuf, size_t bufsize, const char *pathname)
+int get_file_name(char *namebuf, size_t bufsize, const char *pathname)
 {
     int len = strlen(pathname) - 1;
     char *path = strdup(pathname);
 
     if (path == NULL) {
-        exit_toxic_err(FATALERR_MEMORY, "failed in get_file_name");
+        return -1;
     }
 
     while (len >= 0 && pathname[len] == '/') {
-        path[len--] = '\0';
+        path[len] = '\0';
+        --len;
     }
 
     char *finalname = strdup(path);
 
     if (finalname == NULL) {
-        exit_toxic_err(FATALERR_MEMORY, "failed in get_file_name");
+        free(path);
+        return -1;
     }
 
     const char *basenm = strrchr(path, '/');
@@ -391,7 +390,7 @@ size_t get_file_name(char *namebuf, size_t bufsize, const char *pathname)
     free(finalname);
     free(path);
 
-    return strlen(namebuf);
+    return (int)strlen(namebuf);
 }
 
 /* Gets the base directory of path and puts it in dir.

--- a/src/misc_tools.h
+++ b/src/misc_tools.h
@@ -187,8 +187,12 @@ bool valid_nick(const char *nick);
  */
 void filter_string(char *str, size_t len, bool is_nick);
 
-/* gets base file name from path or original file name if no path is supplied */
-size_t get_file_name(char *namebuf, size_t bufsize, const char *pathname);
+/* Gets base file name from path or original file name if no path is supplied.
+ *
+ * Returns the file name length on success.
+ * Returns -1 on failure (OOM).
+ */
+int get_file_name(char *namebuf, size_t bufsize, const char *pathname);
 
 /* Gets the base directory of path and puts it in dir.
  * dir must have at least as much space as path_len.

--- a/src/toxic_constants.h
+++ b/src/toxic_constants.h
@@ -78,16 +78,13 @@ typedef enum _FATAL_ERRS {
     FATALERR_FILEOP = -2,           /* critical file operation failed */
     FATALERR_THREAD_CREATE = -3,    /* thread creation failed for critical thread */
     FATALERR_MUTEX_INIT = -4,       /* mutex init for critical thread failed */
-    FATALERR_THREAD_ATTR = -5,      /* thread attr object init failed */
-    FATALERR_LOCALE_NOT_SET = -6,   /* system locale not set */
-    FATALERR_STORE_DATA = -7,       /* store_data failed in critical section */
-    FATALERR_INFLOOP = -8,          /* infinite loop detected */
-    FATALERR_WININIT = -9,          /* window init failed */
-    FATALERR_PROXY = -10,           /* Tox network failed to init using a proxy */
-    FATALERR_ENCRYPT = -11,         /* Data file encryption failure */
-    FATALERR_TOX_INIT = -12,        /* Tox instance failed to initialize */
-    FATALERR_TOXIC_INIT = -13,      /* Toxic instance failed to initialize */
-    FATALERR_CURSES = -14,          /* Unrecoverable Ncurses error */
+    FATALERR_LOCALE_NOT_SET = -5,   /* system locale not set */
+    FATALERR_WININIT = -6,          /* window init failed */
+    FATALERR_PROXY = -7,            /* Tox network failed to init using a proxy */
+    FATALERR_ENCRYPT = -8,          /* Data file encryption failure */
+    FATALERR_TOX_INIT = -9,         /* Tox instance failed to initialize */
+    FATALERR_TOXIC_INIT = -10,      /* Toxic instance failed to initialize */
+    FATALERR_CURSES = -11,          /* Unrecoverable Ncurses error */
 } FATAL_ERRS;
 
 #endif  // TOXIC_CONSTANTS_H


### PR DESCRIPTION
These fatal errors aren't catastrophic and can be recovered from.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/toxic/356)
<!-- Reviewable:end -->
