### PR TITLE
Makefile: add powerpc case

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,10 @@ endif
 ifneq ($(filter arm%, $(UNAME_M)),)
     -include $(CFG_DIR)/platforms/arm.mk
 endif
+UNAME_P = $(shell uname -p)
+ifeq ($(UNAME_P), powerpc)
+    -include $(CFG_DIR)/platforms/powerpc.mk
+endif
 
 # Include all needed checks
 -include $(CFG_DIR)/checks/check_features.mk


### PR DESCRIPTION
@JFreegman While there are no arch-specific configs at the moment (platforms dir is empty), perhaps add the case of powerpc anyway?

Alternatively, this should also work:
```
ifeq ($(UNAME_M), "Power Macintosh")
    -include $(CFG_DIR)/platforms/powerpc.mk
endif
```
(Yes, `uname -m` returns an awkward value.)