### PR TITLE
fix: message history position on resize

### DIFF
--- a/src/windows.c
+++ b/src/windows.c
@@ -1053,6 +1053,11 @@ void on_window_resize(Windows *windows)
 
         scrollok(w->chatwin->history, 0);
         wmove(w->window, y2 - CURS_Y_OFFSET, 0);
+
+        if (!w->scroll_pause) {
+            ChatContext *ctx = w->chatwin;
+            line_info_reset_start(w, ctx->hst);
+        }
     }
 }
 

--- a/test/toxic.test.ts
+++ b/test/toxic.test.ts
@@ -65,20 +65,13 @@ test.describe("toxic", () => {
 
   test("last message is shown when terminal gets smaller", async ({ terminal }) => {
     await startToxic(terminal);
-    // Add a friend.
-    terminal.write("/add 13117C65771C5A05409F532A7809D238E38E94312C870FE7970C5B65B1215E20CEF40A1D48B7\r");
-    await expect(terminal.getByText("Friend request sent.")).toBeVisible(fast);
-    terminal.write(String.fromCharCode(16));
-    await expect(terminal.getByText("Press the h key")).toBeVisible(fast);
-    terminal.write("\r");
-    await expect(terminal.getByText("[Offline]")).toBeVisible(fast);
     for (let i = 1; i <= 10; ++i) {
         terminal.write(`we're (${i}) writing some pretty long message here, this is message ${i}\r`);
     }
     await expect(terminal.getByText("message 10")).toBeVisible(fast);
     terminal.resize(60, 20);
     // slow, because resize can take a while
-    // TODO(JFreegman): Make this "message 10" when it's fixed.
+    // TODO(iphy): this should be fixed and changed to 10
     await expect(terminal.getByText("message 7")).toBeVisible(slow);
   });
 });


### PR DESCRIPTION
The message history now stays scrolled to the bottom after making the toxic window smaller, unless you aren't already scrolled to the bottom

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/toxic/363)
<!-- Reviewable:end -->
