### PR TITLE
refactor: Move message init queue to separate file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,8 @@ LDFLAGS += ${USER_LDFLAGS}
 
 OBJ = autocomplete.o avatars.o bootstrap.o chat.o chat_commands.o conference.o configdir.o curl_util.o execute.o
 OBJ += file_transfers.o friendlist.o global_commands.o conference_commands.o groupchats.o groupchat_commands.o help.o
-OBJ += input.o line_info.o log.o main.o message_queue.o misc_tools.o name_lookup.o notify.o prompt.o qr_code.o settings.o
-OBJ += term_mplex.o toxic.o toxic_strings.o windows.o
+OBJ += init_queue.o input.o line_info.o log.o main.o message_queue.o misc_tools.o name_lookup.o notify.o prompt.o qr_code.o
+OBJ += settings.o term_mplex.o toxic.o toxic_strings.o windows.o
 
 # Check if debug build is enabled
 RELEASE := $(shell if [ -z "$(ENABLE_RELEASE)" ] || [ "$(ENABLE_RELEASE)" = "0" ] ; then echo disabled ; else echo enabled ; fi)

--- a/src/init_queue.c
+++ b/src/init_queue.c
@@ -1,0 +1,81 @@
+/*  init_queue.c
+ *
+ *  Copyright (C) 2024 Toxic All Rights Reserved.
+ *
+ *  This file is part of Toxic. Toxic is free software licensed
+ *  under the GNU General Public License 3.0.
+ */
+
+#include "init_queue.h"
+
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "line_info.h"
+#include "toxic.h"
+#include "toxic_constants.h"
+#include "windows.h"
+
+Init_Queue *init_queue_new(void)
+{
+    Init_Queue *init_q = (Init_Queue *) calloc(1, sizeof(Init_Queue));
+    return init_q;
+}
+
+void init_queue_free(Init_Queue *init_q)
+{
+    if (init_q == NULL) {
+        return;
+    }
+
+    for (uint16_t i = 0; i < init_q->count; ++i) {
+        free(init_q->messages[i]);
+    }
+
+    free(init_q->messages);
+    free(init_q);
+}
+
+void init_queue_print(const Init_Queue *init_q, ToxWindow *window, const Client_Config *c_config)
+{
+    if (init_q == NULL) {
+        return;
+    }
+
+    for (uint16_t i = 0; i < init_q->count; ++i) {
+        line_info_add(window, c_config, NULL, NULL, NULL, SYS_MSG, 0, 0, "%s", init_q->messages[i]);
+    }
+}
+
+void init_queue_add(Init_Queue *init_q, const char *message, ...)
+{
+    if (init_q == NULL) {
+        return;
+    }
+
+    char format_message[MAX_STR_SIZE] = {0};
+
+    va_list args;
+    va_start(args, message);
+    vsnprintf(format_message, sizeof(format_message), message, args);
+    va_end(args);
+
+    const uint16_t i = init_q->count;
+
+    char **temp_messages = realloc(init_q->messages, sizeof(char *) * (i + 1));
+
+    if (temp_messages == NULL) {
+        exit_toxic_err(FATALERR_MEMORY, "Failed in init_queue_add");
+    }
+
+    temp_messages[i] = malloc(MAX_STR_SIZE);
+
+    if (temp_messages[i] == NULL) {
+        exit_toxic_err(FATALERR_MEMORY, "Failed in init_queue_add");
+    }
+
+    snprintf(temp_messages[i], MAX_STR_SIZE, "%s", format_message);
+
+    init_q->messages = temp_messages;
+    ++init_q->count;
+}

--- a/src/init_queue.h
+++ b/src/init_queue.h
@@ -1,0 +1,55 @@
+/*  init_queue.h
+ *
+ *  Copyright (C) 2024 Toxic All Rights Reserved.
+ *
+ *  This file is part of Toxic. Toxic is free software licensed
+ *  under the GNU General Public License 3.0.
+ */
+
+#ifndef INIT_QUEUE_H
+#define INIT_QUEUE_H
+
+#include <stdint.h>
+
+#include "toxic.h"
+#include "windows.h"
+
+typedef struct Init_Queue {
+    char     **messages;
+    uint16_t count;
+} Init_Queue;
+
+/*
+ * Adds `message` to `init_q`.
+ *
+ * `init_queue_new()` must be called before using this function.
+ *
+ * If `init_q` is NULL this function has no effect.
+ */
+__attribute__((format(printf, 2, 3)))
+void init_queue_add(Init_Queue *init_q, const char *message, ...);
+
+/*
+ * Frees all memory associated with init_q including the init_q itself.
+ *
+ * If `init_q` is NULL this function has no effect.
+ */
+void init_queue_free(Init_Queue *init_q);
+
+/*
+ * Prints all messages in `init_q` to `window`.
+ *
+ * If `init_q` is NULL this function has no effect.
+ */
+void init_queue_print(const Init_Queue *init_q, ToxWindow *window, const Client_Config *c_config);
+
+/*
+ * Returns a new Init_Queue object on success.
+ * Returns NULL on memory allocation error.
+ *
+ * The caller is responsible for freeing the memory associated with the returned
+ * object with `init_queue_free()`.
+ */
+Init_Queue *init_queue_new(void);
+
+#endif  // INIT_QUEUE_H

--- a/src/toxic.c
+++ b/src/toxic.c
@@ -55,6 +55,7 @@
 #include "file_transfers.h"
 #include "friendlist.h"
 #include "groupchats.h"
+#include "init_queue.h"
 #include "line_info.h"
 #include "log.h"
 #include "message_queue.h"
@@ -85,39 +86,6 @@
 #endif
 
 struct Winthread Winthread;
-
-void queue_init_message(Init_Queue *init_q, const char *message, ...)
-{
-    if (init_q == NULL) {
-        return;
-    }
-
-    char format_message[MAX_STR_SIZE] = {0};
-
-    va_list args;
-    va_start(args, message);
-    vsnprintf(format_message, sizeof(format_message), message, args);
-    va_end(args);
-
-    const uint16_t i = init_q->count;
-
-    char **temp_messages = realloc(init_q->messages, sizeof(char *) * (i + 1));
-
-    if (temp_messages == NULL) {
-        exit_toxic_err(FATALERR_MEMORY, "Failed in queue_init_message");
-    }
-
-    temp_messages[i] = malloc(MAX_STR_SIZE);
-
-    if (temp_messages[i] == NULL) {
-        exit_toxic_err(FATALERR_MEMORY, "Failed in queue_init_message");
-    }
-
-    snprintf(temp_messages[i], MAX_STR_SIZE, "%s", format_message);
-
-    init_q->messages = temp_messages;
-    ++init_q->count;
-}
 
 static void kill_toxic(Toxic *toxic)
 {
@@ -339,7 +307,7 @@ void init_term(const Client_Config *c_config, Init_Queue *init_q, bool use_defau
     set_window_refresh_rate(NCURSES_DEFAULT_REFRESH_RATE);
 
     if (!has_colors()) {
-        queue_init_message(init_q, "This terminal does not support colors.");
+        init_queue_add(init_q, "This terminal does not support colors.");
         refresh();
         return;
     }
@@ -351,7 +319,7 @@ void init_term(const Client_Config *c_config, Init_Queue *init_q, bool use_defau
     short bar_notify_color = COLOR_YELLOW;
 
     if (start_color() != 0) {
-        queue_init_message(init_q, "Failed to initialize ncurses colors.");
+        init_queue_add(init_q, "Failed to initialize ncurses colors.");
         // let's try anyways
     }
 
@@ -405,8 +373,8 @@ void init_term(const Client_Config *c_config, Init_Queue *init_q, bool use_defau
         init_pair(PINK_BAR_FG, CUSTOM_COLOUR_PINK, bar_bg_color);
         init_pair(BROWN_BAR_FG, CUSTOM_COLOUR_BROWN, bar_bg_color);
     } else {
-        queue_init_message(init_q, "This terminal does not support 256-colors. Certain non-default colors may "
-                           "not be displayed properly as a result.");
+        init_queue_add(init_q, "This terminal does not support 256-colors. Certain non-default colors may "
+                       "not be displayed properly as a result.");
     }
 
     refresh();

--- a/src/toxic.h
+++ b/src/toxic.h
@@ -73,11 +73,6 @@ typedef struct Windows {
     uint16_t   active_index;
 } Windows;
 
-typedef struct Init_Queue {
-    char     **messages;
-    uint16_t count;
-} Init_Queue;
-
 typedef struct Toxic {
     Tox   *tox;
 #ifdef AUDIO
@@ -96,18 +91,10 @@ typedef struct Toxic {
     Windows       *windows;
 } Toxic;
 
+typedef struct Init_Queue Init_Queue;
+
 void lock_status(void);
 void unlock_status(void);
-
-/* Puts `message` in the init queue.
- *
- * print_init_queue() prints all messages in the queue to the home window.
- * free_init_queue() must be called after use.
- *
- * If `init_q` is NULL this function has no effect.
- */
-__attribute__((format(printf, 2, 3)))
-void queue_init_message(Init_Queue *init_q, const char *message, ...);
 
 void flag_interface_refresh(void);
 


### PR DESCRIPTION
This functionality was awkwardly placed between main.c and toxic.c. Now it resides on its own as a stand-alone unit.

Also improved documentation and naming scheme, and added some extra null checks.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/toxic/366)
<!-- Reviewable:end -->
