### PR TITLE
fix: chat history scrolling in groups/conferences

### DIFF
--- a/src/conference.c
+++ b/src/conference.c
@@ -367,6 +367,10 @@ void redraw_conference_win(ToxWindow *self)
 
     scrollok(ctx->history, 0);
     wmove(self->window, y2 - CURS_Y_OFFSET, 0);
+
+    if (!self->scroll_pause) {
+        line_info_reset_start(self, ctx->hst);
+    }
 }
 
 static void conference_onConferenceMessage(ToxWindow *self, Toxic *toxic, uint32_t conferencenum, uint32_t peernum,

--- a/src/groupchats.c
+++ b/src/groupchats.c
@@ -945,6 +945,10 @@ void redraw_groupchat_win(ToxWindow *self)
     wmove(self->window, y2 - CURS_Y_OFFSET, 0);
 
     self->x = 0;  // trigger the statusbar to be re-sized
+
+    if (!self->scroll_pause) {
+        line_info_reset_start(self, ctx->hst);
+    }
 }
 
 static void group_onAction(ToxWindow *self, Toxic *toxic, uint32_t groupnumber, uint32_t peer_id, const char *action,


### PR DESCRIPTION
The chat history now stays scrolled to the bottom when you hide or unhide the peer list (unless you're not already scrolled to the bottom)