### PR TITLE
chore: Update the static build script

### DIFF
--- a/script/build-minimal-static-toxic.sh
+++ b/script/build-minimal-static-toxic.sh
@@ -28,7 +28,7 @@
 #
 # Run as:
 #
-#    sudo docker run -it --rm \
+#    sudo docker run -it --rm --pull=always \
 #         -v /tmp/artifact:/artifact \
 #         -v /home/jfreegman/git/toxic:/toxic \
 #         amd64/alpine:latest \

--- a/script/build-minimal-static-toxic.sh
+++ b/script/build-minimal-static-toxic.sh
@@ -247,7 +247,10 @@ cd "$BUILD_DIR"
 cp -a "$TOXIC_SRC_DIR" toxic
 cd toxic
 
-if [ -z "$(git describe --tags --exact-match HEAD)" ]
+git config --global --add safe.directory "$PWD"
+
+TOXIC_TAG="$(git describe --tags --exact-match HEAD || true)"
+if [ -z "$TOXIC_TAG" ]
 then
   set +x
   echo "Didn't find a git tag on the HEAD commit. You seem to be building an in-development release of Toxic rather than a release version." | fold -sw 80
@@ -288,12 +291,20 @@ mv "$PREPARE_ARTIFACT_DIR/toxic.conf.example" "$PREPARE_ARTIFACT_DIR/toxic.conf"
 
 cp -aL /usr/share/terminfo "$PREPARE_ARTIFACT_DIR"
 
+TOXIC_COMMIT="$(git -C "$BUILD_DIR/toxic" rev-parse HEAD)"
+if [ -z "$TOXIC_TAG" ]
+then
+  TOXIC_VERSION="$TOXIC_COMMIT"
+else
+  TOXIC_VERSION="$TOXIC_TAG ($TOXIC_COMMIT)"
+fi
+
 echo "A minimal statically compiled Toxic.
 Doesn't support X11 integration, video/audio calls, desktop & sound
 notifications, QR codes and Python scripting.
 However, it is rather portable.
 
-Toxic $(git -C "$BUILD_DIR/toxic" describe --tags --exact-match HEAD) ($(git -C "$BUILD_DIR/toxic" rev-parse HEAD))
+Toxic $TOXIC_VERSION
 
 Build date time: $(TZ=UTC date +"%Y-%m-%dT%H:%M:%S%z")
 

--- a/script/build-minimal-static-toxic.sh
+++ b/script/build-minimal-static-toxic.sh
@@ -180,20 +180,57 @@ cmake --build _build --target install
 # location with SSL_CERT_FILE env variable.
 cd "$BUILD_DIR"
 
-CURL_VERSION="8.5.0"
-CURL_HASH="05fc17ff25b793a437a0906e0484b82172a9f4de02be5ed447e0cab8c3475add"
-CURL_FILENAME="curl-$CURL_VERSION.tar.gz"
+CURL_VERSION="8.7.1"
+CURL_HASH="6fea2aac6a4610fbd0400afb0bcddbe7258a64c63f1f68e5855ebc0c659710cd"
+CURL_FILENAME="curl-$CURL_VERSION.tar.xz"
 
 wget --timeout=10 -O "$CURL_FILENAME" "https://curl.haxx.se/download/$CURL_FILENAME"
 check_sha256 "$CURL_HASH" "$CURL_FILENAME"
-tar -xf curl*.tar.gz
-rm curl*.tar.gz
+tar -xf "$CURL_FILENAME"
+rm "$CURL_FILENAME"
 cd curl*
 
+# TODO(nurupo): backport of https://github.com/curl/curl/commit/4b42cda3df85419328ba8c9160a3e8306605d094
+#               remove once that commit makes it into a curl release
+sed -i 's/man_MANS = $(MANPAGE)/@BUILD_DOCS_TRUE@man_MANS = $(MANPAGE)/g' docs/cmdline-opts/Makefile.in
 ./configure \
   --prefix="$BUILD_DIR/prefix-curl" \
   --disable-shared \
   --enable-static \
+  --disable-ftp \
+  --disable-file \
+  --disable-ldap \
+  --disable-ldaps \
+  --disable-rtsp \
+  --disable-proxy \
+  --disable-dict \
+  --disable-telnet \
+  --disable-tftp \
+  --disable-pop3 \
+  --disable-imap \
+  --disable-smb \
+  --disable-smtp \
+  --disable-gopher \
+  --disable-mqtt \
+  --disable-docs \
+  --disable-manual \
+  --disable-libcurl-option \
+  --disable-sspi \
+  --disable-basic-auth \
+  --disable-bearer-auth \
+  --disable-digest-auth \
+  --disable-kerberos-auth \
+  --disable-negotiate-auth \
+  --disable-aws \
+  --disable-ntlm \
+  --disable-ntlm-wb \
+  --disable-tls-srp \
+  --disable-unix-sockets \
+  --disable-cookies \
+  --disable-http-auth \
+  --disable-bindlocal \
+  --disable-netrc \
+  --disable-websockets \
   --without-ca-bundle \
   --without-ca-path \
   --with-ca-fallback \

--- a/script/build-minimal-static-toxic.sh
+++ b/script/build-minimal-static-toxic.sh
@@ -306,9 +306,10 @@ However, it is rather portable.
 
 Toxic $TOXIC_VERSION
 
-Build date time: $(TZ=UTC date +"%Y-%m-%dT%H:%M:%S%z")
+Build date-time: $(TZ=UTC date +"%Y-%m-%dT%H:%M:%S%z")
 
 OS:
+$ cat /etc/os-release
 $(cat /etc/os-release)
 
 List of self-built software statically compiled into Toxic:
@@ -316,9 +317,11 @@ libcurl $CURL_VERSION
 libtoxcore $TOXCORE_VERSION
 
 List of OS-packaged software statically compiled into Toxic:
+$ apk list -I | grep 'static' | sort -i
 $(apk list -I | grep 'static' | sort -i)
 
 List of all packages installed during the build:
+$ apk list -I | sort -i
 $(apk list -I | sort -i)" > "$PREPARE_ARTIFACT_DIR/build_info"
 
 echo '#!/usr/bin/env sh

--- a/script/build-minimal-static-toxic.sh
+++ b/script/build-minimal-static-toxic.sh
@@ -304,10 +304,9 @@ TOXIC_GIT_COMMIT="$(git -C "$BUILD_DIR/toxic" rev-parse HEAD)"
 TOXIC_GIT_REV="$(git -C "$BUILD_DIR/toxic" rev-list HEAD --count)"
 TOXIC_VERSION="${TOXIC_GIT_TAG}_r${TOXIC_GIT_REV} ($TOXIC_GIT_COMMIT)"
 
-echo "A minimal statically compiled Toxic.
-Doesn't support X11 integration, video/audio calls, desktop & sound
-notifications, QR codes and Python scripting.
-However, it is rather portable.
+echo "A minimal statically compiled Toxic. Doesn't support X11 integration,
+video/audio calls, desktop & sound notifications, QR codes and Python
+scripting. However, it is rather portable.
 
 Toxic $TOXIC_VERSION
 

--- a/script/build-minimal-static-toxic.sh
+++ b/script/build-minimal-static-toxic.sh
@@ -87,6 +87,9 @@ set -x
 # Use all cores for building
 MAKEFLAGS=j$(nproc)
 export MAKEFLAGS
+# TODO(nurupo): Once GCC 14 comes out, switch to using the new -fhardened
+CFLAGS="-ftrivial-auto-var-init=zero -fPIE -pie -Wl,-z,relro,-z,now -fstack-protector-strong -fstack-clash-protection -fcf-protection=full"
+export CFLAGS
 
 check_sha256()
 {
@@ -266,7 +269,7 @@ fi
 sed -i 's|pkg-config|pkg-config --static|' cfg/global_vars.mk
 sed -i 's|<limits.h|<linux/limits.h|' src/*
 
-CFLAGS="-static" PKG_CONFIG_PATH="$BUILD_DIR/prefix-toxcore/lib64/pkgconfig:$BUILD_DIR/prefix-toxcore/lib/pkgconfig:$BUILD_DIR/prefix-curl/lib/pkgconfig" PREFIX="$BUILD_DIR/prefix-toxic" make \
+CFLAGS="$CFLAGS -static" PKG_CONFIG_PATH="$BUILD_DIR/prefix-toxcore/lib64/pkgconfig:$BUILD_DIR/prefix-toxcore/lib/pkgconfig:$BUILD_DIR/prefix-curl/lib/pkgconfig" PREFIX="$BUILD_DIR/prefix-toxic" make \
   DISABLE_X11=1 \
   DISABLE_AV=1 \
   DISABLE_SOUND_NOTIFY=1 \


### PR DESCRIPTION
- Updated libcurl version
  - Also disabled a lot of unnecessary features
    ```diff
    --- curl-configure-before
    +++ curl-configure-after
    @@ -16,15 +16,15 @@
    zstd:             no      (--with-zstd)
    GSS-API:          no      (--with-gssapi)
    GSASL:            no      (libgsasl not found)
    -  TLS-SRP:          enabled
    +  TLS-SRP:          no      (--enable-tls-srp)
    resolver:         POSIX threaded
    IPv6:             enabled
    -  Unix sockets:     enabled
    +  Unix sockets:     no      (--enable-unix-sockets)
    IDN:              no      (--with-{libidn2,winidn})
    Build docs:       no
    Build libcurl:    Shared=no, Static=yes
    -  Built-in manual:  enabled
    -  --libcurl option: enabled (--disable-libcurl-option)
    +  Built-in manual:  no      (--enable-manual)
    +  --libcurl option: no
    Verbose errors:   enabled (--disable-verbose)
    Code coverage:    disabled
    SSPI:             no      (--enable-sspi)
    @@ -33,7 +33,7 @@
    ca fallback:      yes
    LDAP:             no      (--enable-ldap / --with-ldap-lib / --with-lber-lib)
    LDAPS:            no      (--enable-ldaps)
    -  RTSP:             enabled
    +  RTSP:             no      (--enable-rtsp)
    RTMP:             no      (--with-librtmp)
    PSL:              no      (--with-libpsl)
    Alt-svc:          enabled (--disable-alt-svc)
    @@ -44,5 +44,5 @@
    HTTP3:            no      (--with-ngtcp2 --with-nghttp3, --with-quiche, --with-openssl-quic, --with-msh3)
    ECH:              no      (--enable-ech)
    WebSockets:       no      (--enable-websockets)
    -  Protocols:        DICT FILE FTP FTPS GOPHER GOPHERS HTTP HTTPS IMAP IMAPS IPFS IPNS MQTT POP3 POP3S RTSP SMB SMBS SMTP SMTPS TELNET TFTP
    -  Features:         AsynchDNS HSTS HTTP2 HTTPS-proxy IPv6 Largefile NTLM SSL TLS-SRP UnixSockets alt-svc brotli libz threadsafe
    +  Protocols:        HTTP HTTPS IPFS IPNS
    +  Features:         AsynchDNS HSTS HTTP2 IPv6 Largefile SSL alt-svc brotli libz threadsafe
    ```
- Fixed Toxic version and commit not being mentioned in the build_info file due to git not considering the directory as safe and not printing those (it worked before but a git update adding this safety check broke it)
- Documented to pull the up-to-date Alpine:latest image, instead of using the cached one. I noticed that the v0.15.0 release was build on 3.17.2 when the latest is 3.19.1
- Hardened curl, toxcore and toxic builds
- Fixed Toxic version not being printed in the build_info

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/toxic/373)
<!-- Reviewable:end -->
