### PR TITLE
fix: race condition when drawing group/conference peer list

### DIFF
--- a/src/groupchats.c
+++ b/src/groupchats.c
@@ -2145,15 +2145,9 @@ static void groupchat_onDraw(ToxWindow *self, Toxic *toxic)
         uint32_t offset = 0;
 
         pthread_mutex_lock(&Winthread.lock);
-        const uint32_t max_idx = chat->max_idx;
-        const uint32_t start = chat->side_pos;
-        pthread_mutex_unlock(&Winthread.lock);
 
-        for (uint32_t i = start; i < max_idx && offset < maxlines; ++i) {
-            pthread_mutex_lock(&Winthread.lock);
-
+        for (uint32_t i = chat->side_pos; i < chat->max_idx && offset < maxlines; ++i) {
             if (!chat->peer_list[i].active) {
-                pthread_mutex_unlock(&Winthread.lock);
                 continue;
             }
 
@@ -2194,8 +2188,6 @@ static void groupchat_onDraw(ToxWindow *self, Toxic *toxic)
                 rolecolour = MAGENTA;
             }
 
-            pthread_mutex_unlock(&Winthread.lock);
-
             if (is_ignored) {
                 wattron(ctx->sidebar, COLOR_PAIR(RED) | A_BOLD);
                 wprintw(ctx->sidebar, "#");
@@ -2212,6 +2204,8 @@ static void groupchat_onDraw(ToxWindow *self, Toxic *toxic)
 
             ++offset;
         }
+
+        pthread_mutex_unlock(&Winthread.lock);
     }
 
     int y;


### PR DESCRIPTION
The number of peers can change between and within iterations leading to an out of bounds index. Now we just lock the entire loop, which is less efficient but necessary.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/toxic/376)
<!-- Reviewable:end -->
