### PR TITLE
feat: Allow friend invites from group and conference windows

### DIFF
--- a/src/chat_commands.c
+++ b/src/chat_commands.c
@@ -119,7 +119,7 @@ void cmd_cancelfile(WINDOW *window, ToxWindow *self, Toxic *toxic, int argc, cha
     close_file_transfer(self, toxic, ft, TOX_FILE_CONTROL_CANCEL, msg, silent);
 }
 
-void cmd_conference_invite(WINDOW *window, ToxWindow *self, Toxic *toxic, int argc, char (*argv)[MAX_STR_SIZE])
+void cmd_invite_to_conference(WINDOW *window, ToxWindow *self, Toxic *toxic, int argc, char (*argv)[MAX_STR_SIZE])
 {
     UNUSED_VAR(window);
 
@@ -275,7 +275,7 @@ void cmd_group_accept(WINDOW *window, ToxWindow *self, Toxic *toxic, int argc, c
     }
 }
 
-void cmd_group_invite(WINDOW *window, ToxWindow *self, Toxic *toxic, int argc, char (*argv)[MAX_STR_SIZE])
+void cmd_invite_to_group(WINDOW *window, ToxWindow *self, Toxic *toxic, int argc, char (*argv)[MAX_STR_SIZE])
 {
     if (toxic == NULL || self == NULL) {
         return;

--- a/src/chat_commands.h
+++ b/src/chat_commands.h
@@ -14,10 +14,10 @@
 
 void cmd_autoaccept_files(WINDOW *window, ToxWindow *, Toxic *, int argc, char (*argv)[MAX_STR_SIZE]);
 void cmd_cancelfile(WINDOW *window, ToxWindow *, Toxic *, int argc, char (*argv)[MAX_STR_SIZE]);
-void cmd_conference_invite(WINDOW *, ToxWindow *, Toxic *, int argc, char (*argv)[MAX_STR_SIZE]);
+void cmd_invite_to_conference(WINDOW *, ToxWindow *, Toxic *, int argc, char (*argv)[MAX_STR_SIZE]);
 void cmd_conference_join(WINDOW *, ToxWindow *, Toxic *, int argc, char (*argv)[MAX_STR_SIZE]);
 void cmd_group_accept(WINDOW *window, ToxWindow *, Toxic *, int argc, char (*argv)[MAX_STR_SIZE]);
-void cmd_group_invite(WINDOW *window, ToxWindow *, Toxic *, int argc, char (*argv)[MAX_STR_SIZE]);
+void cmd_invite_to_group(WINDOW *window, ToxWindow *, Toxic *, int argc, char (*argv)[MAX_STR_SIZE]);
 void cmd_game_join(WINDOW *, ToxWindow *, Toxic *, int argc, char (*argv)[MAX_STR_SIZE]);
 void cmd_savefile(WINDOW *, ToxWindow *, Toxic *, int argc, char (*argv)[MAX_STR_SIZE]);
 void cmd_sendfile(WINDOW *, ToxWindow *, Toxic *, int argc, char (*argv)[MAX_STR_SIZE]);

--- a/src/conference_commands.h
+++ b/src/conference_commands.h
@@ -13,6 +13,7 @@
 #include "windows.h"
 
 void cmd_conference_chatid(WINDOW *window, ToxWindow *self, Toxic *toxic, int argc, char (*argv)[MAX_STR_SIZE]);
+void cmd_conference_invite(WINDOW *window, ToxWindow *self, Toxic *toxic, int argc, char (*argv)[MAX_STR_SIZE]);
 void cmd_conference_set_title(WINDOW *, ToxWindow *, Toxic *, int argc, char (*argv)[MAX_STR_SIZE]);
 void cmd_enable_audio(WINDOW *, ToxWindow *, Toxic *, int argc, char (*argv)[MAX_STR_SIZE]);
 void cmd_conference_mute(WINDOW *, ToxWindow *, Toxic *, int argc, char (*argv)[MAX_STR_SIZE]);

--- a/src/execute.c
+++ b/src/execute.c
@@ -71,10 +71,10 @@ static struct cmd_func global_commands[] = {
 static struct cmd_func chat_commands[] = {
     { "/autoaccept", cmd_autoaccept_files  },
     { "/cancel",    cmd_cancelfile        },
-    { "/cinvite",   cmd_conference_invite },
+    { "/cinvite",   cmd_invite_to_conference },
     { "/cjoin",     cmd_conference_join   },
     { "/gaccept",   cmd_group_accept      },
-    { "/invite",    cmd_group_invite      },
+    { "/invite",    cmd_invite_to_group   },
 #ifdef GAMES
     { "/play",      cmd_game_join         },
 #endif
@@ -99,6 +99,7 @@ static struct cmd_func chat_commands[] = {
 
 static struct cmd_func conference_commands[] = {
     { "/chatid",    cmd_conference_chatid    },
+    { "/cinvite",   cmd_conference_invite    },
     { "/title",     cmd_conference_set_title },
 
 #ifdef AUDIO
@@ -112,8 +113,9 @@ static struct cmd_func conference_commands[] = {
 
 static struct cmd_func groupchat_commands[] = {
     { "/chatid",    cmd_chatid         },
-    { "/disconnect", cmd_disconnect     },
+    { "/disconnect", cmd_disconnect    },
     { "/ignore",    cmd_ignore         },
+    { "/invite",    cmd_group_invite   },
     { "/kick",      cmd_kick           },
     { "/list",      cmd_list           },
     { "/locktopic", cmd_set_topic_lock },
@@ -137,9 +139,11 @@ static struct cmd_func groupchat_commands[] = {
 static const char special_commands[][MAX_CMDNAME_SIZE] = {
     "/add",
     "/avatar",
+    "/cinvite",
     "/gaccept",
     "/group",
     "/ignore",
+    "/invite",
     "/kick",
     "/mod",
     "/nick",

--- a/src/friendlist.c
+++ b/src/friendlist.c
@@ -1424,6 +1424,24 @@ void disable_friend_window(uint32_t f_num)
     Friends.list[f_num].window_id = -1;
 }
 
+size_t friendlist_get_count(void)
+{
+    return Friends.num_friends;
+}
+
+void friendlist_get_names(char **names, size_t max_names, size_t max_name_size)
+{
+    if (Friends.num_friends == 0) {
+        return;
+    }
+
+    const size_t bytes_to_copy = MIN(sizeof(Friends.list[0].name), max_name_size);
+
+    for (size_t i = 0; i < max_names && i < Friends.num_friends; ++i) {
+        snprintf(names[i], bytes_to_copy, "%s", Friends.list[i].name);
+    }
+}
+
 #ifdef AUDIO
 static void friendlist_onAV(ToxWindow *self, Toxic *toxic, uint32_t friend_number, int state)
 {
@@ -1455,6 +1473,7 @@ static void friendlist_onAV(ToxWindow *self, Toxic *toxic, uint32_t friend_numbe
         set_active_window_by_id(toxic->windows, window_id);
     }
 }
+
 #endif /* AUDIO */
 
 /* Returns a friend's status */
@@ -1475,6 +1494,29 @@ Tox_Connection get_friend_connection_status(uint32_t friendnumber)
     }
 
     return Friends.list[friendnumber].connection_status;
+}
+
+int64_t get_friend_number_name(const char *name, uint16_t length)
+{
+    int64_t num = -1;
+    bool match_found = false;
+
+    for (size_t i = 0; i < Friends.max_idx; ++i) {
+        if (length != Friends.list[i].namelength) {
+            continue;
+        }
+
+        if (memcmp(name, Friends.list[i].name, length) == 0) {
+            if (match_found) {
+                return -2;
+            }
+
+            num = Friends.list[i].num;
+            match_found = true;
+        }
+    }
+
+    return num;
 }
 
 /*

--- a/src/friendlist.h
+++ b/src/friendlist.h
@@ -125,6 +125,19 @@ Tox_User_Status get_friend_status(uint32_t friendnumber);
 Tox_Connection get_friend_connection_status(uint32_t friendnumber);
 
 /*
+ * Returns the number of friends in the friend list.
+ */
+size_t friendlist_get_count(void);
+
+/*
+ * Copies names from the friends list into the `names` array.
+ *
+ * @max_names The maximum number of names to copy.
+ * @max_name_size The maximum number of bytes to copy per name.
+ */
+void friendlist_get_names(char **names, size_t max_names, size_t max_name_size);
+
+/*
  * Loads the list of blocked peers from `path`.
  *
  * Returns 0 on success or if the file doesn't exist (a file will only exist if
@@ -161,6 +174,16 @@ bool friend_get_auto_accept_files(uint32_t friendnumber);
  * Returns the length of the name.
  */
 uint16_t get_friend_name(char *buf, size_t buf_size, uint32_t friendnumber);
+
+/*
+ * Returns the friend number associated with `name`.
+ *
+ * @length The length of the name.
+ *
+ * Returns -1 if `name` does not designate a friend in the friend list.
+ * Returns -2 if `name` matches more than one friend in the friend list.
+ */
+int64_t get_friend_number_name(const char *name, uint16_t length);
 
 /*
  * Puts a friend's public key in `pk`, which must have room for at least

--- a/src/groupchat_commands.h
+++ b/src/groupchat_commands.h
@@ -14,6 +14,7 @@
 
 void cmd_chatid(WINDOW *, ToxWindow *, Toxic *, int argc, char (*argv)[MAX_STR_SIZE]);
 void cmd_disconnect(WINDOW *, ToxWindow *, Toxic *, int argc, char (*argv)[MAX_STR_SIZE]);
+void cmd_group_invite(WINDOW *, ToxWindow *, Toxic *, int argc, char (*argv)[MAX_STR_SIZE]);
 void cmd_group_nick(WINDOW *, ToxWindow *, Toxic *, int argc, char (*argv)[MAX_STR_SIZE]);
 void cmd_ignore(WINDOW *, ToxWindow *, Toxic *, int argc, char (*argv)[MAX_STR_SIZE]);
 void cmd_kick(WINDOW *, ToxWindow *, Toxic *, int argc, char (*argv)[MAX_STR_SIZE]);

--- a/src/help.c
+++ b/src/help.c
@@ -234,9 +234,9 @@ static void help_draw_chat(ToxWindow *self)
     wattroff(win, A_BOLD | COLOR_PAIR(RED));
 
     wprintw(win, "  /autoaccept <on>|<off>     : Toggle auto-accepting file transfers\n");
-    wprintw(win, "  /cinvite <n>               : Invite contact to a conference \n");
+    wprintw(win, "  /cinvite <conference num>  : Invite contact to a conference \n");
     wprintw(win, "  /cjoin                     : Join a pending conference\n");
-    wprintw(win, "  /invite <n>                : Invite contact to a groupchat \n");
+    wprintw(win, "  /invite <group num>        : Invite contact to a groupchat \n");
     wprintw(win, "  /gaccept <password>        : Accept a pending groupchat invite\n");
     wprintw(win, "  /sendfile <path>           : Send a file\n");
     wprintw(win, "  /savefile <id>             : Receive a file\n");
@@ -291,6 +291,7 @@ static void help_draw_groupchats(ToxWindow *self)
     wprintw(win, "  /disconnect               : Disconnect from the group (credentials retained)\n");
     wprintw(win, "  /ignore <name>|<key>      : Ignore a peer\n");
     wprintw(win, "  /unignore <name>|<key>    : Unignore a peer\n");
+    wprintw(win, "  /invite <name>            : Invite a friend to the group\n");
     wprintw(win, "  /kick <name>|<key>        : Remove a peer from the group\n");
     wprintw(win, "  /list                     : Print a list of peers currently in the group\n");
     wprintw(win, "  /locktopic                : Set the topic lock: on | off\n");
@@ -353,6 +354,7 @@ static void help_draw_conference(ToxWindow *self)
     wattroff(win, A_BOLD | COLOR_PAIR(RED));
 
     wprintw(win, "  /chatid                 : Print this conference's ID\n");
+    wprintw(win, "  /cinvite                : Invite a friend to this conference\n");
     wprintw(win, "  /title <msg>            : Show/set conference title\n");
 #ifdef AUDIO
     wattron(win, A_BOLD);
@@ -456,7 +458,7 @@ void help_onKey(ToxWindow *self, wint_t key)
             break;
 
         case L'o':
-            height = 7;
+            height = 8;
 #ifdef AUDIO
             height += 7;
 #endif
@@ -488,7 +490,7 @@ void help_onKey(ToxWindow *self, wint_t key)
             break;
 
         case L'r':
-            help_init_window(self, 27, 80);
+            help_init_window(self, 28, 80);
             self->help->type = HELP_GROUP;
             break;
     }


### PR DESCRIPTION
Friends from the friend list can now be invited to groups and conferences with the /invite and /cinvite commands respectively.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/toxic/387)
<!-- Reviewable:end -->
