### PR TITLE
feat: Add the ability to pass a password to the groupchat /rejoin command

### DIFF
--- a/src/execute.c
+++ b/src/execute.c
@@ -145,6 +145,7 @@ static const char special_commands[][MAX_CMDNAME_SIZE] = {
     "/nick",
     "/note",
     "/passwd",
+    "/rejoin",
     "/silence",
     "/topic",
     "/unignore",

--- a/src/global_commands.c
+++ b/src/global_commands.c
@@ -566,8 +566,8 @@ void cmd_groupchat(WINDOW *window, ToxWindow *self, Toxic *toxic, int argc, char
     self_nick[nick_length] = '\0';
 
     Tox_Err_Group_New err;
-    uint32_t groupnumber = tox_group_new(tox, TOX_GROUP_PRIVACY_STATE_PUBLIC, (const uint8_t *) name, len,
-                                         (const uint8_t *) self_nick, nick_length, &err);
+    const uint32_t groupnumber = tox_group_new(tox, TOX_GROUP_PRIVACY_STATE_PUBLIC, (const uint8_t *) name, len,
+                                 (const uint8_t *) self_nick, nick_length, &err);
 
     if (err != TOX_ERR_GROUP_NEW_OK) {
         switch (err) {
@@ -622,6 +622,11 @@ void cmd_join(WINDOW *window, ToxWindow *self, Toxic *toxic, int argc, char (*ar
 
     if (strlen(chat_id) != TOX_GROUP_CHAT_ID_SIZE * 2) {
         line_info_add(self, c_config, false, NULL, NULL, SYS_MSG, 0, 0, "Invalid chat ID");
+        return;
+    }
+
+    if (get_groupnumber_by_public_key_string(chat_id) != -1) {
+        line_info_add(self, c_config, false, NULL, NULL, SYS_MSG, 0, 0, "You are already in this group.");
         return;
     }
 
@@ -860,6 +865,7 @@ void cmd_myqr(WINDOW *window, ToxWindow *self, Toxic *toxic, int argc, char (*ar
 
     free(dir);
 }
+
 #endif /* QRCODE */
 
 void cmd_nick(WINDOW *window, ToxWindow *self, Toxic *toxic, int argc, char (*argv)[MAX_STR_SIZE])

--- a/src/groupchats.c
+++ b/src/groupchats.c
@@ -140,13 +140,7 @@ GroupChat *get_groupchat(uint32_t groupnumber)
     return NULL;
 }
 
-/*
- * Return the groupnumber associated with `public_key`.
- * Return -1 if public_key does not designate a valid group.
- *
- * `public_key` must be a string of at least TOX_PUBLIC_KEY_SIZE * 2 chars in length.
- */
-static int get_groupnumber_by_public_key_string(const char *public_key)
+int get_groupnumber_by_public_key_string(const char *public_key)
 {
     char pk_bin[TOX_PUBLIC_KEY_SIZE];
 

--- a/src/groupchats.h
+++ b/src/groupchats.h
@@ -71,6 +71,14 @@ void groupchat_onGroupModeration(ToxWindow *self, Toxic *toxic, uint32_t groupnu
 
 void groupchat_rejoin(ToxWindow *self, Toxic *toxic);
 
+/*
+ * Return the groupnumber associated with `public_key`.
+ * Return -1 if public_key does not designate a valid group.
+ *
+ * `public_key` must be a string of at least TOX_PUBLIC_KEY_SIZE * 2 chars in length.
+ */
+int get_groupnumber_by_public_key_string(const char *public_key);
+
 /* Updates the groupchat topic in the top statusbar. */
 void groupchat_update_statusbar_topic(ToxWindow *self, const Tox *tox);
 

--- a/src/help.c
+++ b/src/help.c
@@ -296,10 +296,10 @@ static void help_draw_groupchats(ToxWindow *self)
     wprintw(win, "  /locktopic                : Set the topic lock: on | off\n");
     wprintw(win, "  /mod <name>|<key>         : Promote a peer to moderator\n");
     wprintw(win, "  /nick <name>              : Set your name (for this group only)\n");
-    wprintw(win, "  /passwd <s>               : Set a password to join the group\n");
+    wprintw(win, "  /passwd <password>        : Set a password to join the group\n");
     wprintw(win, "  /peerlimit <n>            : Set the maximum number of peers that can join\n");
     wprintw(win, "  /privacy <state>          : Set the privacy state: private | public\n");
-    wprintw(win, "  /rejoin                   : Reconnect to the group\n");
+    wprintw(win, "  /rejoin <password>        : Reconnect to the group (password is optional)\n");
     wprintw(win, "  /silence <name>|<key>     : Silence a peer for the entire group\n");
     wprintw(win, "  /unsilence <name>|<key>   : Unsilence a silenced peer\n");
     wprintw(win, "  /status <type>            : Set your status (client-wide)\n");
@@ -389,6 +389,7 @@ static void help_draw_plugin(ToxWindow *self)
     box(win, ACS_VLINE, ACS_HLINE);
     wnoutrefresh(win);
 }
+
 #endif /* PYTHON */
 
 static void help_draw_contacts(ToxWindow *self)


### PR DESCRIPTION
This replaces the deprecated tox_group_reconnect command with tox_group_join which now supports the ability to reconnect to groups with a password.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/toxic/391)
<!-- Reviewable:end -->
