### PR TITLE
fix: help menu bugs

### DIFF
--- a/src/groupchats.c
+++ b/src/groupchats.c
@@ -2228,7 +2228,7 @@ static void groupchat_onDraw(ToxWindow *self, Toxic *toxic)
 
     draw_window_bar(self, toxic->windows);
 
-    wrefresh(self->window);
+    wnoutrefresh(self->window);
 
     if (self->help->active) {
         help_draw_main(self);

--- a/src/help.c
+++ b/src/help.c
@@ -18,9 +18,9 @@
 #endif /* PYTHON */
 
 #ifdef PYTHON
-#define HELP_MENU_HEIGHT 10
+#define HELP_MENU_HEIGHT 11
 #else
-#define HELP_MENU_HEIGHT 9
+#define HELP_MENU_HEIGHT 10
 #endif /* PYTHON */
 #define HELP_MENU_WIDTH 26
 


### PR DESCRIPTION
- The help menu should no longer flicker in group chats
- The main menu now properly shows the exit option

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/toxic/392)
<!-- Reviewable:end -->
