### PR TITLE
feat: Add word block list to config

### DIFF
--- a/doc/toxic.conf.5
+++ b/doc/toxic.conf.5
@@ -2,12 +2,12 @@
 .\"     Title: toxic.conf
 .\"    Author: [see the "AUTHORS" section]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 2024-02-09
+.\"      Date: 2024-12-23
 .\"    Manual: Toxic Manual
 .\"    Source: toxic __VERSION__
 .\"  Language: English
 .\"
-.TH "TOXIC\&.CONF" "5" "2024\-02\-09" "toxic __VERSION__" "Toxic Manual"
+.TH "TOXIC\&.CONF" "5" "2024\-12\-23" "toxic __VERSION__" "Toxic Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -366,6 +366,11 @@ Enable or disable autologging\&. true or false
 .RS 4
 The colour of the conferences\(cqs tab window name\&. (black, white, gray, brown, red, green, blue, cyan, yellow, magenta, orange, pink)
 .RE
+.RE
+.PP
+\fBblocked_words\fR
+.RS 4
+A list of case\-insensitive words that cannot be sent in messages\&. String value\&. Must be enclosed in double quotes and must be ⇐ 256 characters\&.
 .RE
 .PP
 \fBsounds\fR

--- a/doc/toxic.conf.5.asc
+++ b/doc/toxic.conf.5.asc
@@ -229,6 +229,9 @@ OPTIONS
     *tab_name_colour*;;
         The colour of the conferences's tab window name. (black, white, gray, brown, red, green, blue, cyan, yellow, magenta, orange, pink)
 
+*blocked_words*::
+    A list of case-insensitive words that cannot be sent in messages. String value. Must be enclosed in double quotes and must be <= 256 characters.
+
 *sounds*::
     Configuration related to notification sounds.
     Special value "silent" can be used to disable a specific notification. +

--- a/misc/toxic.conf.example
+++ b/misc/toxic.conf.example
@@ -206,6 +206,15 @@ conferences = {
 // };
 };
 
+// A list of case-insensitive words that cannot be sent in messages. If you attempt to send
+// a message that contains a word in this list to a group, friend, etc., the message will not
+// send and an error will be displayed. Words must be enclosed in double quotes and must not
+// be longer than 256 characters.
+blocked_words = [
+  // "hunter2",
+  // "certainly!"
+];
+
 // To disable a sound set the path to "silent"
 sounds = {
   error="__DATADIR__/sounds/ToxicError.wav";

--- a/src/api.c
+++ b/src/api.c
@@ -219,4 +219,5 @@ void invoke_autoruns(ToxWindow *self, const char *autorun_path)
 
     closedir(d);
 }
+
 #endif /* PYTHON */

--- a/src/audio_call.c
+++ b/src/audio_call.c
@@ -449,6 +449,7 @@ void callback_recv_invite(Toxic *toxic, uint32_t friend_number)
         }
     }
 }
+
 void callback_recv_ringing(Toxic *toxic, uint32_t friend_number)
 {
     if (friend_number >= CallControl.max_calls) {
@@ -466,6 +467,7 @@ void callback_recv_ringing(Toxic *toxic, uint32_t friend_number)
         }
     }
 }
+
 void callback_recv_starting(Toxic *toxic, uint32_t friend_number)
 {
     if (friend_number >= CallControl.max_calls) {
@@ -484,6 +486,7 @@ void callback_recv_starting(Toxic *toxic, uint32_t friend_number)
         }
     }
 }
+
 void callback_call_started(Toxic *toxic, uint32_t friend_number)
 {
     if (friend_number >= CallControl.max_calls) {
@@ -502,6 +505,7 @@ void callback_call_started(Toxic *toxic, uint32_t friend_number)
         }
     }
 }
+
 void callback_call_canceled(Toxic *toxic, uint32_t friend_number)
 {
     if (friend_number >= CallControl.max_calls) {
@@ -519,6 +523,7 @@ void callback_call_canceled(Toxic *toxic, uint32_t friend_number)
         }
     }
 }
+
 void callback_call_rejected(Toxic *toxic, uint32_t friend_number)
 {
     if (friend_number >= CallControl.max_calls) {
@@ -536,6 +541,7 @@ void callback_call_rejected(Toxic *toxic, uint32_t friend_number)
         }
     }
 }
+
 void callback_call_ended(Toxic *toxic, uint32_t friend_number)
 {
     if (friend_number >= CallControl.max_calls) {

--- a/src/audio_device.c
+++ b/src/audio_device.c
@@ -200,7 +200,7 @@ void get_al_device_names(void)
 
         if (stringed_device_list != NULL) {
             audio_state->default_al_device_name[type] = alcGetString(NULL,
-                    type == input ? ALC_CAPTURE_DEFAULT_DEVICE_SPECIFIER : ALC_DEFAULT_DEVICE_SPECIFIER);
+                type == input ? ALC_CAPTURE_DEFAULT_DEVICE_SPECIFIER : ALC_DEFAULT_DEVICE_SPECIFIER);
 
             for (; *stringed_device_list != '\0'
                     && audio_state->num_al_devices[type] < MAX_OPENAL_DEVICES; ++audio_state->num_al_devices[type]) {
@@ -341,7 +341,7 @@ static DeviceError open_al_device(DeviceType type, FrameInfo frame_info)
 {
     audio_state->al_device[type] = type == input
                                    ? alcCaptureOpenDevice(audio_state->current_al_device_name[type],
-                                           frame_info.sample_rate, sound_mode(frame_info.stereo), frame_info.samples_per_frame * 2)
+                                       frame_info.sample_rate, sound_mode(frame_info.stereo), frame_info.samples_per_frame * 2)
                                    : alcOpenDevice(audio_state->current_al_device_name[type]);
 
     if (audio_state->al_device[type] == NULL) {
@@ -754,6 +754,7 @@ static void *poll_input(void *arg)
 
     pthread_exit(NULL);
 }
+
 #endif
 
 float get_input_volume(void)

--- a/src/conference.c
+++ b/src/conference.c
@@ -1042,16 +1042,19 @@ static bool conference_onKey(ToxWindow *self, Toxic *toxic, wint_t key, bool ltr
         input_ret = true;
         rm_trailing_spaces_buf(ctx);
 
-        if (!wstring_is_empty(ctx->line)) {
+        wstrsubst(ctx->line, L'¶', L'\n');
+
+        char line[MAX_STR_SIZE];
+
+        if (wcs_to_mbs_buf(line, ctx->line, MAX_STR_SIZE) == -1) {
+            memset(line, 0, sizeof(line));
+            line_info_add(self, c_config, false, NULL, NULL, SYS_MSG, 0, RED, " * Failed to parse message.");
+        }
+
+        const bool contains_blocked_word = string_contains_blocked_word(line, &toxic->client_data);
+
+        if (line[0] != '\0' && !contains_blocked_word) {
             add_line_to_hist(ctx);
-
-            wstrsubst(ctx->line, L'¶', L'\n');
-
-            char line[MAX_STR_SIZE];
-
-            if (wcs_to_mbs_buf(line, ctx->line, MAX_STR_SIZE) == -1) {
-                memset(line, 0, sizeof(line));
-            }
 
             if (line[0] == '/') {
                 if (strcmp(line, "/close") == 0) {
@@ -1062,20 +1065,22 @@ static bool conference_onKey(ToxWindow *self, Toxic *toxic, wint_t key, bool ltr
                 } else {
                     execute(ctx->history, self, toxic, line, CONFERENCE_COMMAND_MODE);
                 }
-            } else if (line[0]) {
+            } else {
                 Tox_Err_Conference_Send_Message err;
 
                 if (!tox_conference_send_message(tox, self->num, TOX_MESSAGE_TYPE_NORMAL, (uint8_t *) line, strlen(line), &err)) {
                     line_info_add(self, c_config, false, NULL, NULL, SYS_MSG, 0, RED, " * Failed to send message (error %d)", err);
                 }
-            } else {
-                line_info_add(self, c_config, false, NULL, NULL, SYS_MSG, 0, RED, " * Failed to parse message.");
             }
         }
 
-        wclear(ctx->linewin);
-        wmove(self->window, y2, 0);
-        reset_buf(ctx);
+        if (!contains_blocked_word) {
+            wclear(ctx->linewin);
+            wmove(self->window, y2, 0);
+            reset_buf(ctx);
+        } else {
+            line_info_add(self, c_config, false, NULL, NULL, SYS_MSG, 0, RED, "* Message contains blocked word");
+        }
     }
 
     return input_ret;

--- a/src/main.c
+++ b/src/main.c
@@ -1329,6 +1329,12 @@ int main(int argc, char **argv)
         init_queue_add(init_q, "Failed to load conference config settings: error %d", cs_ret);
     }
 
+    const int bl_ret = settings_load_blocked_words(&toxic->client_data, run_opts);
+
+    if (bl_ret != 0) {
+        init_queue_add(init_q, "Failed to load blocked words list: error %d", bl_ret);
+    }
+
     set_active_window_by_type(windows, WINDOW_TYPE_PROMPT);
 
     if (pthread_mutex_init(&Winthread.lock, NULL) != 0) {

--- a/src/misc_tools.c
+++ b/src/misc_tools.c
@@ -6,6 +6,10 @@
  *  under the GNU General Public License 3.0.
  */
 
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE    /* needed for strcasestr() */
+#endif
+
 #include <assert.h>
 #include <arpa/inet.h>
 #include <ctype.h>
@@ -679,7 +683,7 @@ void free_ptr_array(void **arr)
 
     void **tmp = arr;
 
-    while (*arr) {
+    while (*arr != NULL) {
         free(*arr);
         ++arr;
     }
@@ -788,4 +792,15 @@ size_t format_time_str(char *s, size_t max, const char *format, const struct tm 
 #pragma GCC diagnostic ignored "-Wformat-nonliteral"
     return strftime(s, max, format, tm);
 #pragma GCC diagnostic pop
+}
+
+bool string_contains_blocked_word(const char *line, const Client_Data *client_data)
+{
+    for (size_t i = 0; i < client_data->num_blocked_words; ++i) {
+        if (strcasestr(line, client_data->blocked_words[i]) != NULL) {
+            return true;
+        }
+    }
+
+    return false;
 }

--- a/src/misc_tools.h
+++ b/src/misc_tools.h
@@ -293,8 +293,14 @@ int colour_string_to_int(const char *colour);
  */
 size_t format_time_str(char *s, size_t max, const char *format, const struct tm *tm);
 
+/*
+ * Returns true if `line` contains a word that's in the client's blocked words list.
+ */
+bool string_contains_blocked_word(const char *line, const Client_Data *client_data);
+
 #ifdef __cplusplus
 } /* extern "C" */
+
 #endif /* __cplusplus */
 
 #endif /* MISC_TOOLS_H */

--- a/src/notify.c
+++ b/src/notify.c
@@ -90,6 +90,7 @@ static struct _ActiveNotifications {
     time_t n_timeout;
 #endif /* BOX_NOTIFY */
 } actives[ACTIVE_NOTIFS_MAX];
+
 /**********************************************************************************/
 /**********************************************************************************/
 /**********************************************************************************/
@@ -582,6 +583,7 @@ void stop_sound(int id)
         clear_actives_index(id);
     }
 }
+
 #endif /* SOUND_NOTIFY */
 
 static int m_play_sound(const Client_Config *c_config, Notification notif, uint64_t flags)

--- a/src/prompt.c
+++ b/src/prompt.c
@@ -276,26 +276,34 @@ static bool prompt_onKey(ToxWindow *self, Toxic *toxic, wint_t key, bool ltr)
 
         rm_trailing_spaces_buf(ctx);
 
-        if (!wstring_is_empty(ctx->line)) {
-            add_line_to_hist(ctx);
-            wstrsubst(ctx->line, L'¶', L'\n');
+        wstrsubst(ctx->line, L'¶', L'\n');
 
-            char line[MAX_STR_SIZE];
+        char line[MAX_STR_SIZE];
 
-            if (wcs_to_mbs_buf(line, ctx->line, MAX_STR_SIZE) == -1) {
-                line_info_add(self, c_config, false, NULL, NULL, SYS_MSG, 0, RED, " * Failed to parse message.");
-            } else {
-                if (strcmp(line, "/clear") != 0) {
-                    line_info_add(self, c_config, false, NULL, NULL, PROMPT, 0, 0, "%s", line);
-                }
-
-                execute(ctx->history, self, toxic, line, GLOBAL_COMMAND_MODE);
-            }
+        if (wcs_to_mbs_buf(line, ctx->line, MAX_STR_SIZE) == -1) {
+            memset(line, 0, sizeof(line));
+            line_info_add(self, c_config, false, NULL, NULL, SYS_MSG, 0, RED, " * Failed to parse message.");
         }
 
-        wclear(ctx->linewin);
-        wmove(self->window, y2, 0);
-        reset_buf(ctx);
+        const bool contains_blocked_word = string_contains_blocked_word(line, &toxic->client_data);
+
+        if (line[0] != '\0' && !contains_blocked_word) {
+            add_line_to_hist(ctx);
+
+            if (strcmp(line, "/clear") != 0) {
+                line_info_add(self, c_config, false, NULL, NULL, PROMPT, 0, 0, "%s", line);
+            }
+
+            execute(ctx->history, self, toxic, line, GLOBAL_COMMAND_MODE);
+        }
+
+        if (!contains_blocked_word) {
+            wclear(ctx->linewin);
+            wmove(self->window, y2, 0);
+            reset_buf(ctx);
+        } else {
+            line_info_add(self, c_config, false, NULL, NULL, SYS_MSG, 0, RED, "* Message contains blocked word");
+        }
     }
 
     return input_ret;

--- a/src/python_api.c
+++ b/src/python_api.c
@@ -352,4 +352,5 @@ void python_draw_handler_help(WINDOW *win)
         }
     }
 }
+
 #endif /* PYTHON */

--- a/src/qr_code.c
+++ b/src/qr_code.c
@@ -211,6 +211,7 @@ int ID_to_QRcode_png(const char *tox_id, const char *outfile)
 
     return 0;
 }
+
 #endif /* QRPNG */
 
 #endif /* QRCODE */

--- a/src/settings.h
+++ b/src/settings.h
@@ -22,6 +22,7 @@
 #define PASSWORD_EVAL_MAX 512
 
 typedef struct Toxic Toxic;
+typedef struct Client_Data Client_Data;
 
 /* Holds user setting values defined in the toxic config file. */
 typedef struct Client_Config {
@@ -166,6 +167,17 @@ int settings_load_groups(Windows *windows, const Run_Options *run_opts);
  * This function will have no effect on conference instances that are created in the future.
  */
 int settings_load_conferences(Windows *windows, const Run_Options *run_opts);
+
+/*
+ * Loads the blocked words list from the toxic config file pointed to by `patharg`.
+ * If `patharg` is null, the default config path is used.
+ *
+ * Return 0 on success (or if no list exists in the config file).
+ * Return -1 if we fail to open the file path.
+ * Return -2 if libconfig fails to read the config file.
+ * Return -3 if memory allocation fails.
+ */
+int settings_load_blocked_words(Client_Data *client_data, const Run_Options *run_opts);
 
 /*
  * Reloads config settings.

--- a/src/toxic.c
+++ b/src/toxic.c
@@ -83,6 +83,7 @@ static void kill_toxic(Toxic *toxic)
 
     free(client_data->data_path);
     free(client_data->block_path);
+    free_ptr_array((void **) client_data->blocked_words);
     free(toxic->c_config);
     free(toxic->run_opts);
     free(toxic->windows);

--- a/src/toxic.h
+++ b/src/toxic.h
@@ -54,6 +54,8 @@ typedef struct Client_Data {
     int  pass_len;
     char *data_path;
     char *block_path;
+    char **blocked_words;
+    size_t num_blocked_words;
 } Client_Data;
 
 typedef struct ToxAV ToxAV;

--- a/src/toxic_constants.h
+++ b/src/toxic_constants.h
@@ -43,6 +43,8 @@
 #define MIN_PASSWORD_LEN 6
 #define MAX_PASSWORD_LEN 64
 
+#define MAX_BLOCKED_WORD_LENGTH 256  /* Max length of words in the blocked words list */
+
 /* Fixes text color problem on some terminals.
    Uncomment if necessary */
 /* #define URXVT_FIX */

--- a/src/video_call.c
+++ b/src/video_call.c
@@ -182,6 +182,7 @@ int stop_video_transmission(Call *call, int friend_number)
 
     return 0;
 }
+
 /*
  * End of transmission
  */
@@ -236,6 +237,7 @@ void callback_recv_video_starting(uint32_t friend_number)
 
     open_primary_video_device(vdt_output, &this_call->vout_idx, NULL, NULL);
 }
+
 void callback_recv_video_end(uint32_t friend_number)
 {
     if (friend_number >= CallControl.max_calls) {
@@ -251,6 +253,7 @@ void callback_recv_video_end(uint32_t friend_number)
     close_video_device(vdt_output, this_call->vout_idx);
     this_call->vout_idx = -1;
 }
+
 static void callback_video_starting(Toxic *toxic, uint32_t friend_number)
 {
     if (friend_number >= CallControl.max_calls) {
@@ -278,6 +281,7 @@ static void callback_video_starting(Toxic *toxic, uint32_t friend_number)
         }
     }
 }
+
 void callback_video_end(uint32_t friend_number)
 {
     if (friend_number >= CallControl.max_calls) {
@@ -286,6 +290,7 @@ void callback_video_end(uint32_t friend_number)
 
     stop_video_transmission(&CallControl.calls[friend_number], friend_number);
 }
+
 /*
  * End of Callbacks
  */

--- a/src/windows.c
+++ b/src/windows.c
@@ -1326,7 +1326,8 @@ void draw_active_window(Toxic *toxic)
             return;
         }
 
-        // if an unprintable key code is unrecognized by input handler we attempt to manually decode char sequence
+        // if an unprintable key code is unrecognized by input handler we attempt to
+        // manually decode char sequence
         wint_t tmp = get_input_sequence_code();
 
         if (tmp != (wint_t) -1) {


### PR DESCRIPTION
A list of blocked words can now be added to the config file. Any message that contains a word on the list will not be able to send, and will cause an error message to be displayed.
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/toxic/394)
<!-- Reviewable:end -->
