### PR TITLE
cleanup: Stop using deprecated names for things in tox.h.

### DIFF
--- a/src/groupchats.c
+++ b/src/groupchats.c
@@ -16,7 +16,6 @@
 #include <time.h>
 #include <wchar.h>
 #include <unistd.h>
-#include <inttypes.h>
 
 #ifdef AUDIO
 #ifdef __APPLE__
@@ -46,7 +45,6 @@
 #include "help.h"
 #include "notify.h"
 #include "autocomplete.h"
-#include "audio_device.h"
 
 extern char *DATA_FILE;
 static int max_groupchat_index = 0;
@@ -118,7 +116,7 @@ static int realloc_peer_list(uint32_t groupnumber, uint32_t n);
 static void groupchat_onGroupNickChange(ToxWindow *self, Toxic *toxic, uint32_t groupnumber, uint32_t peer_id,
                                         const char *new_nick, size_t len);
 static void groupchat_onGroupStatusChange(ToxWindow *self, Toxic *toxic, uint32_t groupnumber, uint32_t peer_id,
-        TOX_USER_STATUS status);
+        Tox_User_Status status);
 static void groupchat_onGroupSelfNickChange(ToxWindow *self, Toxic *toxic, uint32_t groupnumber, const char *old_nick,
         size_t old_length, const char *new_nick, size_t length);
 static void ignore_list_cleanup(GroupChat *chat);
@@ -526,8 +524,8 @@ void set_status_all_groups(Toxic *toxic, uint8_t status)
                 continue;
             }
 
-            if (tox_group_self_set_status(toxic->tox, self->num, (TOX_USER_STATUS) status, NULL)) {
-                groupchat_onGroupStatusChange(self, toxic, self->num, self_peer_id, (TOX_USER_STATUS) status);
+            if (tox_group_self_set_status(toxic->tox, self->num, (Tox_User_Status) status, NULL)) {
+                groupchat_onGroupStatusChange(self, toxic, self->num, self_peer_id, (Tox_User_Status) status);
             }
         }
     }
@@ -973,7 +971,7 @@ static void group_onAction(ToxWindow *self, Toxic *toxic, uint32_t groupnumber, 
 }
 
 static void groupchat_onGroupMessage(ToxWindow *self, Toxic *toxic, uint32_t groupnumber, uint32_t peer_id,
-                                     TOX_MESSAGE_TYPE type, const char *msg, size_t len)
+                                     Tox_Message_Type type, const char *msg, size_t len)
 {
     if (toxic == NULL || self == NULL) {
         return;
@@ -1719,7 +1717,7 @@ static void groupchat_onGroupNickChange(ToxWindow *self, Toxic *toxic, uint32_t 
 }
 
 static void groupchat_onGroupStatusChange(ToxWindow *self, Toxic *toxic, uint32_t groupnumber, uint32_t peer_id,
-        TOX_USER_STATUS status)
+        Tox_User_Status status)
 {
     UNUSED_VAR(toxic);
 
@@ -1748,7 +1746,7 @@ static void groupchat_onGroupStatusChange(ToxWindow *self, Toxic *toxic, uint32_
 }
 
 static void send_group_message(ToxWindow *self, Toxic *toxic, uint32_t groupnumber, const char *msg,
-                               TOX_MESSAGE_TYPE type)
+                               Tox_Message_Type type)
 {
     if (toxic == NULL || self == NULL) {
         return;

--- a/src/groupchats.h
+++ b/src/groupchats.h
@@ -31,7 +31,7 @@ typedef struct GroupPeer {
     char             prev_name[TOX_MAX_NAME_LENGTH];
     uint32_t         peer_id;
     uint8_t          public_key[TOX_GROUP_PEER_PUBLIC_KEY_SIZE];
-    TOX_USER_STATUS  status;
+    Tox_User_Status  status;
     Tox_Group_Role   role;
     bool             is_ignored;
     uint64_t         last_active;

--- a/src/main.c
+++ b/src/main.c
@@ -143,7 +143,7 @@ static const char *tox_log_level_show(Tox_Log_Level level)
     return "<invalid>";
 }
 
-static void cb_toxcore_logger(Tox *tox, TOX_LOG_LEVEL level, const char *file, uint32_t line, const char *func,
+static void cb_toxcore_logger(Tox *tox, Tox_Log_Level level, const char *file, uint32_t line, const char *func,
                               const char *message, void *user_data)
 {
     UNUSED_VAR(tox);

--- a/src/toxic.h
+++ b/src/toxic.h
@@ -131,11 +131,10 @@ void on_friend_typing(Tox *tox, uint32_t friendnumber, bool is_typing, void *use
 void on_friend_read_receipt(Tox *tox, uint32_t friendnumber, uint32_t receipt, void *userdata);
 void on_lossless_custom_packet(Tox *tox, uint32_t friendnumber, const uint8_t *data, size_t length, void *userdata);
 void on_group_invite(Tox *tox, uint32_t friendnumber, const uint8_t *invite_data, size_t length,
-                     const uint8_t *group_name,
-                     size_t group_name_length, void *userdata);
-void on_group_message(Tox *tox, uint32_t groupnumber, uint32_t peernumber, TOX_MESSAGE_TYPE type,
+                     const uint8_t *group_name, size_t group_name_length, void *userdata);
+void on_group_message(Tox *tox, uint32_t groupnumber, uint32_t peernumber, Tox_Message_Type type,
                       const uint8_t *message, size_t length, Tox_Group_Message_Id message_id, void *userdata);
-void on_group_private_message(Tox *tox, uint32_t groupnumber, uint32_t peernumber, TOX_MESSAGE_TYPE type,
+void on_group_private_message(Tox *tox, uint32_t groupnumber, uint32_t peernumber, Tox_Message_Type type,
                               const uint8_t *message, size_t length, Tox_Group_Message_Id message_id, void *userdata);
 void on_group_peer_join(Tox *tox, uint32_t groupnumber, uint32_t peernumber, void *userdata);
 void on_group_peer_exit(Tox *tox, uint32_t groupnumber, uint32_t peer_id, Tox_Group_Exit_Type exit_type,
@@ -149,7 +148,7 @@ void on_group_topic_lock(Tox *tox, uint32_t groupnumber, Tox_Group_Topic_Lock to
 void on_group_password(Tox *tox, uint32_t groupnumber, const uint8_t *password, size_t length, void *userdata);
 void on_group_nick_change(Tox *tox, uint32_t groupnumber, uint32_t peernumber, const uint8_t *newname, size_t length,
                           void *userdata);
-void on_group_status_change(Tox *tox, uint32_t groupnumber, uint32_t peernumber, TOX_USER_STATUS status,
+void on_group_status_change(Tox *tox, uint32_t groupnumber, uint32_t peernumber, Tox_User_Status status,
                             void *userdata);
 void on_group_self_join(Tox *tox, uint32_t groupnumber, void *userdata);
 void on_group_rejected(Tox *tox, uint32_t groupnumber, Tox_Group_Join_Fail type, void *userdata);

--- a/src/windows.c
+++ b/src/windows.c
@@ -7,7 +7,6 @@
  */
 
 #include <assert.h>
-#include <ctype.h>
 #include <pthread.h>
 #include <stdlib.h>
 #include <string.h>
@@ -469,7 +468,7 @@ void on_group_invite(Tox *tox, uint32_t friendnumber, const uint8_t *invite_data
     }
 }
 
-void on_group_message(Tox *tox, uint32_t groupnumber, uint32_t peer_id, TOX_MESSAGE_TYPE type,
+void on_group_message(Tox *tox, uint32_t groupnumber, uint32_t peer_id, Tox_Message_Type type,
                       const uint8_t *message, size_t length, Tox_Group_Message_Id message_id, void *userdata)
 {
     UNUSED_VAR(message_id);
@@ -490,7 +489,7 @@ void on_group_message(Tox *tox, uint32_t groupnumber, uint32_t peer_id, TOX_MESS
     }
 }
 
-void on_group_private_message(Tox *tox, uint32_t groupnumber, uint32_t peer_id, TOX_MESSAGE_TYPE type,
+void on_group_private_message(Tox *tox, uint32_t groupnumber, uint32_t peer_id, Tox_Message_Type type,
                               const uint8_t *message, size_t length, Tox_Group_Message_Id message_id,
                               void *userdata)
 {
@@ -513,7 +512,7 @@ void on_group_private_message(Tox *tox, uint32_t groupnumber, uint32_t peer_id, 
     }
 }
 
-void on_group_status_change(Tox *tox, uint32_t groupnumber, uint32_t peer_id, TOX_USER_STATUS status, void *userdata)
+void on_group_status_change(Tox *tox, uint32_t groupnumber, uint32_t peer_id, Tox_User_Status status, void *userdata)
 {
     UNUSED_VAR(tox);
 
@@ -1192,6 +1191,7 @@ static struct key_sequence_codes {
     wchar_t *code;
     wint_t   key;
 } Keys[] = {
+
     { L"[1;5A", T_KEY_C_UP    },
     { L"[1;5B", T_KEY_C_DOWN  },
     { L"[1;5C", T_KEY_C_RIGHT },

--- a/src/windows.h
+++ b/src/windows.h
@@ -172,14 +172,13 @@ struct ToxWindow {
 #endif // GAMES
 
     void(*onGroupInvite)(ToxWindow *, Toxic *, uint32_t, const char *, size_t, const char *, size_t);
-    void(*onGroupMessage)(ToxWindow *, Toxic *, uint32_t, uint32_t, TOX_MESSAGE_TYPE, const char *, size_t);
+    void(*onGroupMessage)(ToxWindow *, Toxic *, uint32_t, uint32_t, Tox_Message_Type, const char *, size_t);
     void(*onGroupPrivateMessage)(ToxWindow *, Toxic *, uint32_t, uint32_t, const char *, size_t);
     void(*onGroupPeerJoin)(ToxWindow *, Toxic *, uint32_t, uint32_t);
     void(*onGroupPeerExit)(ToxWindow *, Toxic *, uint32_t, uint32_t, Tox_Group_Exit_Type, const char *, size_t,
-                           const char *,
-                           size_t);
+                           const char *, size_t);
     void(*onGroupNickChange)(ToxWindow *, Toxic *, uint32_t, uint32_t, const char *, size_t);
-    void(*onGroupStatusChange)(ToxWindow *, Toxic *, uint32_t, uint32_t, TOX_USER_STATUS);
+    void(*onGroupStatusChange)(ToxWindow *, Toxic *, uint32_t, uint32_t, Tox_User_Status);
     void(*onGroupTopicChange)(ToxWindow *, Toxic *, uint32_t, uint32_t, const char *, size_t);
     void(*onGroupPeerLimit)(ToxWindow *, Toxic *, uint32_t, uint32_t);
     void(*onGroupPrivacyState)(ToxWindow *, Toxic *, uint32_t, Tox_Group_Privacy_State);
@@ -267,6 +266,7 @@ struct infobox {
 
     WINDOW *win;
 };
+
 #endif /* AUDIO */
 
 #define MAX_LINE_HIST 128


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/toxic/395)
<!-- Reviewable:end -->
