### PR TITLE
fix: null pointer dereference on video call activation

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -6,7 +6,6 @@ bazel-opt_task:
     memory: 2G
   configure_script:
     - /src/workspace/tools/inject-repo toxic
-    - sed -i -e 's/build --config=remote/#&/' /src/workspace/.bazelrc.local
   test_all_script:
     - cd /src/workspace && bazel test -k
         //toxic/...

--- a/src/game_base.c
+++ b/src/game_base.c
@@ -924,11 +924,8 @@ static ToxWindow *game_new_window(Tox *tox, GameType type, uint32_t friendnumber
         char buf[sizeof(name) + sizeof(ret->name) + 4];
         snprintf(buf, sizeof(buf), "%s (%s)", window_name, name);
 
-        const size_t name_size = sizeof(ret->name);
-
-        buf[name_size - 1] = '\0';
-
-        snprintf(ret->name, name_size, "%s", buf);
+        const size_t title_size = MIN(strlen(buf) + 1, sizeof(ret->name));
+        snprintf(ret->name, title_size, "%s", buf);
     } else {
         snprintf(ret->name, sizeof(ret->name), "%s", window_name);
     }

--- a/src/video_call.c
+++ b/src/video_call.c
@@ -158,8 +158,9 @@ int start_video_transmission(ToxWindow *self, Toxic *toxic, Call *call)
         return -1;
     }
 
-    if (!toxav_video_set_bit_rate(toxic->av, self->num, call->video_bit_rate, NULL)) {
-        line_info_add(self, c_config, false, NULL, NULL, SYS_MSG, 0, 0, "Failed to set video bit rate");
+    Toxav_Err_Bit_Rate_Set err;
+    if (!toxav_video_set_bit_rate(toxic->av, self->num, call->video_bit_rate, &err)) {
+        line_info_add(self, c_config, false, NULL, NULL, SYS_MSG, 0, 0, "Failed to set video bit rate: error %d", err);
         return -1;
     }
 
@@ -271,7 +272,7 @@ static void callback_video_starting(Toxic *toxic, uint32_t friend_number)
         for (uint16_t i = 0; i < windows->count; ++i) {
             ToxWindow *window = windows->list[i];
 
-            if (window->is_call && window->num != friend_number) {
+            if (!window->is_call || window->num != friend_number) {
                 continue;
             }
 

--- a/src/video_call.c
+++ b/src/video_call.c
@@ -159,6 +159,7 @@ int start_video_transmission(ToxWindow *self, Toxic *toxic, Call *call)
     }
 
     Toxav_Err_Bit_Rate_Set err;
+
     if (!toxav_video_set_bit_rate(toxic->av, self->num, call->video_bit_rate, &err)) {
         line_info_add(self, c_config, false, NULL, NULL, SYS_MSG, 0, 0, "Failed to set video bit rate: error %d", err);
         return -1;

--- a/src/video_device.c
+++ b/src/video_device.c
@@ -172,8 +172,8 @@ VideoDeviceError init_video_devices(Toxic *toxic)
 
     for (; c_size[vdt_input] <= MAX_DEVICES; ++c_size[vdt_input]) {
         int fd;
-        char device_address[] = "/dev/videoXX";
-        snprintf(device_address + 10, sizeof(char) * strlen(device_address) - 10, "%i", c_size[vdt_input]);
+        char device_address[MAX_STR_SIZE];
+        snprintf(device_address, sizeof(device_address), "/dev/video%i", c_size[vdt_input]);
 
         fd = open(device_address, O_RDWR | O_NONBLOCK, 0);
 
@@ -375,8 +375,8 @@ VideoDeviceError open_video_device(VideoDeviceType type, int32_t selection, uint
 
 #else /* not __OSX__ || __APPLE__ */
         /* Open selected device */
-        char device_address[] = "/dev/videoXX";
-        snprintf(device_address + 10, sizeof(device_address) - 10, "%i", selection);
+        char device_address[MAX_STR_SIZE];
+        snprintf(device_address, sizeof(device_address), "/dev/video%i", selection);
 
         device->fd = open(device_address, O_RDWR);
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/toxic/399)
<!-- Reviewable:end -->
