### PR TITLE
chore: Move bazel build to circleci for now.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,19 @@
+---
+version: 2
+
+workflows:
+  version: 2
+  circleci:
+    jobs:
+      - bazel-opt
+
+jobs:
+  bazel-opt:
+    working_directory: /tmp/cirrus-ci-build
+    docker:
+      - image: toxchat/toktok-stack:latest-release
+
+    steps:
+      - checkout
+      - run: /src/workspace/tools/inject-repo toxic
+      - run: cd /src/workspace && bazel test -k //toxic/...

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,11 +1,11 @@
----
-bazel-opt_task:
-  container:
-    image: toxchat/toktok-stack:latest-release
-    cpu: 2
-    memory: 2G
-  configure_script:
-    - /src/workspace/tools/inject-repo toxic
-  test_all_script:
-    - cd /src/workspace && bazel test -k
-        //toxic/...
+# ---
+# bazel-opt_task:
+#   container:
+#     image: toxchat/toktok-stack:latest-release
+#     cpu: 2
+#     memory: 2G
+#   configure_script:
+#     - /src/workspace/tools/inject-repo toxic
+#   test_all_script:
+#     - cd /src/workspace && bazel test -k
+#         //toxic/...


### PR DESCRIPTION
Maybe we can add a freebsd build to cirrus.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/toxic/402)
<!-- Reviewable:end -->
