### PR TITLE
fix: pointer use after free on config reload failure

### DIFF
--- a/src/settings.c
+++ b/src/settings.c
@@ -1102,6 +1102,7 @@ void settings_reload(Toxic *toxic)
     }
 
     free_ptr_array((void **) client_data->blocked_words);
+    client_data->blocked_words = NULL;
 
     ret = settings_load_blocked_words(client_data, run_opts);
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/toxic/404)
<!-- Reviewable:end -->
