### PR TITLE
fix: config changes to mplex auto-away now work in running sessions

### DIFF
--- a/src/settings.c
+++ b/src/settings.c
@@ -17,6 +17,7 @@
 #include "friendlist.h"
 #include "groupchats.h"
 #include "misc_tools.h"
+#include "term_mplex.h"
 #include "notify.h"
 #include "toxic.h"
 #include "windows.h"
@@ -667,6 +668,7 @@ int settings_load_blocked_words(Client_Data *client_data, const Run_Options *run
     const int list_size = config_setting_length(setting);
 
     if (list_size <= 0) {
+        config_destroy(cfg);
         return 0;
     }
 
@@ -675,6 +677,7 @@ int settings_load_blocked_words(Client_Data *client_data, const Run_Options *run
 
     if (words_list == NULL) {
         fprintf(stderr, "config error: failed to allocate memory for blocked words list.\n");
+        config_destroy(cfg);
         return -3;
     }
 
@@ -1108,6 +1111,10 @@ void settings_reload(Toxic *toxic)
 
     if (ret < 0) {
         fprintf(stderr, "Failed to reload blocked words list (error %d)\n", ret);
+    }
+
+    if (init_mplex_away_timer(toxic) == -1) {
+        fprintf(stderr, "Failed to initialize mplex auto-away.\n");
     }
 
     endwin();

--- a/src/term_mplex.c
+++ b/src/term_mplex.c
@@ -356,14 +356,23 @@ fail:
    sample its state and update away status according to attached/detached state
    of the mplex.
  */
-static int mplex_is_detached(void)
+static bool mplex_is_detached(void)
 {
-    return gnu_screen_is_detached()  ||  tmux_is_detached();
+    return gnu_screen_is_detached() || tmux_is_detached();
 }
 
 static void mplex_timer_handler(Toxic *toxic)
 {
     if (toxic == NULL) {
+        return;
+    }
+
+    pthread_mutex_lock(&Winthread.lock);
+    const bool auto_away_enabled = toxic->c_config->mplex_away;
+    pthread_mutex_unlock(&Winthread.lock);
+
+    // needed in case config is changed during a running session
+    if (!auto_away_enabled) {
         return;
     }
 
@@ -376,7 +385,7 @@ static void mplex_timer_handler(Toxic *toxic)
         return;
     }
 
-    int detached = mplex_is_detached();
+    const bool detached = mplex_is_detached();
 
     pthread_mutex_lock(&Winthread.lock);
     current_status = tox_self_get_status(toxic->tox);
@@ -391,11 +400,11 @@ static void mplex_timer_handler(Toxic *toxic)
         prev_status = current_status;
         new_status = TOX_USER_STATUS_AWAY;
         pthread_mutex_lock(&Winthread.lock);
-        size_t slen = tox_self_get_status_message_size(toxic->tox);
+        const size_t slen = tox_self_get_status_message_size(toxic->tox);
         tox_self_get_status_message(toxic->tox, (uint8_t *) prev_note);
         prev_note[slen] = '\0';
-        pthread_mutex_unlock(&Winthread.lock);
         new_note = toxic->c_config->mplex_away_note;
+        pthread_mutex_unlock(&Winthread.lock);
     } else {
         return;
     }
@@ -414,7 +423,7 @@ static void mplex_timer_handler(Toxic *toxic)
 }
 
 /* Time in seconds between calls to mplex_timer_handler */
-#define MPLEX_TIMER_INTERVAL 5
+#define MPLEX_TIMER_INTERVAL 2
 
 _Noreturn static void *mplex_timer_thread(void *data)
 {
@@ -432,6 +441,14 @@ int init_mplex_away_timer(Toxic *toxic)
         return 0;
     }
 
+    if (toxic == NULL) {
+        return -1;
+    }
+
+    if (toxic->client_data.mplex_auto_away_initialized) {
+        return 0;
+    }
+
     if (!toxic->c_config->mplex_away) {
         return 0;
     }
@@ -444,6 +461,8 @@ int init_mplex_away_timer(Toxic *toxic)
     if (pthread_create(&mplex_tid, NULL, mplex_timer_thread, (void *)toxic) != 0) {
         return -1;
     }
+
+    toxic->client_data.mplex_auto_away_initialized = true;
 
     return 0;
 }

--- a/src/toxic.h
+++ b/src/toxic.h
@@ -56,6 +56,7 @@ typedef struct Client_Data {
     char *block_path;
     char **blocked_words;
     size_t num_blocked_words;
+    bool mplex_auto_away_initialized;
 } Client_Data;
 
 typedef struct ToxAV ToxAV;


### PR DESCRIPTION
This fixes https://github.com/JFreegman/toxic/issues/674

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/toxic/406)
<!-- Reviewable:end -->
