### PR TITLE
fix: correctly set nanosleep time

### DIFF
--- a/src/misc_tools.c
+++ b/src/misc_tools.c
@@ -66,8 +66,8 @@ void sleep_thread(long int usec)
     struct timespec req;
     struct timespec rem;
 
-    req.tv_sec = 0;
-    req.tv_nsec = usec * 1000L;
+    req.tv_sec = usec / (1000L * 1000L);
+    req.tv_nsec = (usec - (req.tv_sec * 1000L * 1000L)) * 1000L;
 
     if (nanosleep(&req, &rem) == -1) {
         if (nanosleep(&rem, NULL) == -1) {


### PR DESCRIPTION
so we can sleep into the seconds range

fixes: https://github.com/JFreegman/toxic/issues/678

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/toxic/408)
<!-- Reviewable:end -->
