### PR TITLE
refactor: Centralize environment variable access

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ LDFLAGS += ${USER_LDFLAGS}
 
 OBJ = autocomplete.o avatars.o bootstrap.o chat.o chat_commands.o conference.o configdir.o curl_util.o execute.o
 OBJ += file_transfers.o friendlist.o global_commands.o conference_commands.o groupchats.o groupchat_commands.o help.o
-OBJ += init_queue.o input.o line_info.o log.o main.o message_queue.o misc_tools.o name_lookup.o notify.o prompt.o qr_code.o
+OBJ += init_queue.o input.o line_info.o log.o main.o message_queue.o misc_tools.o name_lookup.o notify.o paths.o prompt.o qr_code.o
 OBJ += settings.o term_mplex.o toxic.o toxic_strings.o windows.o
 
 # Check if debug build is enabled

--- a/src/autocomplete.c
+++ b/src/autocomplete.c
@@ -331,12 +331,13 @@ static int complete_path(ToxWindow *self, Toxic *toxic, const char *const *list,
 }
 
 /* Transforms a tab complete starting with the shorthand "~" into the full home directory. */
-static void complete_home_dir(ToxWindow *self, char *path, int pathsize, const char *cmd, int cmdlen)
+static void complete_home_dir(ToxWindow *self, const Paths *paths, char *path, int pathsize,
+                              const char *cmd, int cmdlen)
 {
     ChatContext *ctx = self->chatwin;
 
     char homedir[MAX_STR_SIZE] = {0};
-    get_home_dir(homedir, sizeof(homedir));
+    get_home_dir(paths, homedir, sizeof(homedir));
 
     char newline[MAX_STR_SIZE + 1];
     snprintf(newline, sizeof(newline), "%s %s%s", cmd, homedir, path + 1);
@@ -394,7 +395,7 @@ int dir_match(ToxWindow *self, Toxic *toxic, const wchar_t *line, const wchar_t 
     }
 
     if (b_path[0] == '~') {
-        complete_home_dir(self, b_path, sizeof(b_path) - 1, b_cmd, strlen(b_cmd) + 2);
+        complete_home_dir(self, toxic->paths, b_path, sizeof(b_path) - 1, b_cmd, strlen(b_cmd) + 2);
     }
 
     int si = char_rfind(b_path, '/', strlen(b_path));

--- a/src/bootstrap.c
+++ b/src/bootstrap.c
@@ -344,13 +344,13 @@ static int update_DHT_nodeslist(const Run_Options *run_opts, const char *nodes_p
     return 1;
 }
 
-static void get_nodeslist_path(const Run_Options *run_opts, char *buf, size_t buf_size)
+static void get_nodeslist_path(const Run_Options *run_opts, const Paths *paths, char *buf, size_t buf_size)
 {
     char *config_dir = NULL;
 
     if (!string_is_empty(run_opts->nodes_path)) {
         snprintf(buf, buf_size, "%s", run_opts->nodes_path);
-    } else if ((config_dir = get_user_config_dir()) != NULL) {
+    } else if ((config_dir = get_user_config_dir(paths)) != NULL) {
         snprintf(buf, buf_size, "%s%s%s", config_dir, CONFIGDIR, DEFAULT_NODES_FILENAME);
         free(config_dir);
     } else {
@@ -508,7 +508,7 @@ static void *load_nodeslist_thread(void *data)
     }
 
     char nodes_path[PATH_MAX];
-    get_nodeslist_path(toxic->run_opts, nodes_path, sizeof(nodes_path));
+    get_nodeslist_path(toxic->run_opts, toxic->paths, nodes_path, sizeof(nodes_path));
 
     FILE *fp = NULL;
 

--- a/src/chat.c
+++ b/src/chat.c
@@ -336,7 +336,7 @@ static void chat_onNickRefresh(ToxWindow *self, Toxic *toxic)
     char other_key[TOX_PUBLIC_KEY_SIZE];
 
     if (get_friend_public_key(other_key, self->num)) {
-        if (rename_logfile(toxic->windows, toxic->c_config, statusbar->nick, new_name, self_key, other_key,
+        if (rename_logfile(toxic->windows, toxic->c_config, toxic->paths, statusbar->nick, new_name, self_key, other_key,
                            self->id) != 0) {
             fprintf(stderr, "failed to rename logfile\n");
         }
@@ -1678,7 +1678,7 @@ static void chat_init_log(ToxWindow *self, Toxic *toxic, const char *self_nick)
     char myid[TOX_ADDRESS_SIZE];
     tox_self_get_address(tox, (uint8_t *) myid);
 
-    if (log_init(ctx->log, c_config, self_nick, myid, Friends.list[self->num].pub_key, LOG_TYPE_CHAT) != 0) {
+    if (log_init(ctx->log, c_config, toxic->paths, self_nick, myid, Friends.list[self->num].pub_key, LOG_TYPE_CHAT) != 0) {
         line_info_add(self, c_config, false, NULL, NULL, SYS_MSG, 0, 0, "Failed to initialize chat log.");
         return;
     }

--- a/src/conference.c
+++ b/src/conference.c
@@ -170,7 +170,8 @@ static void init_conference_logging(ToxWindow *self, Toxic *toxic, uint32_t conf
     char conference_id[TOX_CONFERENCE_ID_SIZE];
     tox_conference_get_id(tox, conferencenum, (uint8_t *) conference_id);
 
-    if (log_init(ctx->log, c_config, conferences[self->num].title, my_id, conference_id, LOG_TYPE_CHAT) != 0) {
+    if (log_init(ctx->log, c_config, toxic->paths, conferences[self->num].title,
+                 my_id, conference_id, LOG_TYPE_CHAT) != 0) {
         line_info_add(self, c_config, false, NULL, NULL, SYS_MSG, 0, 0, "Warning: Log failed to initialize.");
         return;
     }
@@ -323,7 +324,7 @@ void conference_rename_log_path(Toxic *toxic, uint32_t conferencenum, const char
     char conference_id[TOX_CONFERENCE_ID_SIZE];
     tox_conference_get_id(toxic->tox, conferencenum, (uint8_t *) conference_id);
 
-    if (rename_logfile(toxic->windows, toxic->c_config, chat->title, new_title, myid, conference_id,
+    if (rename_logfile(toxic->windows, toxic->c_config, toxic->paths, chat->title, new_title, myid, conference_id,
                        chat->window_id) != 0) {
         fprintf(stderr, "Failed to rename conference log to '%s'\n", new_title);
     }

--- a/src/configdir.h
+++ b/src/configdir.h
@@ -20,17 +20,20 @@
 #define S_ISDIR(mode)  (((mode) & S_IFMT) == S_IFDIR)
 #endif
 
+#include "paths.h"
+
 /**
  * @brief Get the user's config directory.
  *
  * This is without a trailing slash. Resulting string must be freed.
  *
+ * @param paths The paths object.
  * @return The users config dir or NULL on error.
  */
-char *get_user_config_dir(void);
+char *get_user_config_dir(const Paths *paths);
 
 /* get the user's home directory. */
-void get_home_dir(char *home, int size);
+void get_home_dir(const Paths *paths, char *home, int size);
 
 /* Creates the config and chatlog directories.
  *

--- a/src/friendlist.c
+++ b/src/friendlist.c
@@ -481,7 +481,7 @@ static void friendlist_onNickChange(ToxWindow *self, Toxic *toxic, uint32_t num,
     tox_self_get_address(toxic->tox, (uint8_t *) myid);
 
     if (strcmp(oldname, newnamecpy) != 0) {
-        if (rename_logfile(toxic->windows, toxic->c_config, oldname, newnamecpy, myid, Friends.list[num].pub_key,
+        if (rename_logfile(toxic->windows, toxic->c_config, toxic->paths, oldname, newnamecpy, myid, Friends.list[num].pub_key,
                            Friends.list[num].window_id) != 0) {
             fprintf(stderr, "Failed to rename friend chat log from `%s` to `%s`\n", oldname, newnamecpy);
         }

--- a/src/groupchats.c
+++ b/src/groupchats.c
@@ -328,7 +328,7 @@ static void init_groupchat_log(ToxWindow *self, Toxic *toxic, uint32_t groupnumb
         return;
     }
 
-    if (log_init(ctx->log, c_config, chat->group_name, my_id, chat_id, LOG_TYPE_CHAT) != 0) {
+    if (log_init(ctx->log, c_config, toxic->paths, chat->group_name, my_id, chat_id, LOG_TYPE_CHAT) != 0) {
         line_info_add(self, c_config, false, NULL, NULL, SYS_MSG, 0, 0, "Warning: Log failed to initialize.");
         return;
     }

--- a/src/log.c
+++ b/src/log.c
@@ -31,8 +31,8 @@
  * Return path length on success.
  * Return -1 if the path is too long.
  */
-static int create_log_path(const Client_Config *c_config, char *dest, int destsize, const char *name,
-                           const char *selfkey, const char *otherkey)
+static int create_log_path(const Client_Config *c_config, const Paths *paths, char *dest, int destsize,
+                           const char *name, const char *selfkey, const char *otherkey)
 {
     if (!valid_nick(name)) {
         name = UNKNOWN_NAME;
@@ -41,7 +41,7 @@ static int create_log_path(const Client_Config *c_config, char *dest, int destsi
     const char *namedash = otherkey ? "-" : "";
     const char *set_path = c_config->chatlogs_path;
 
-    char *user_config_dir = get_user_config_dir();
+    char *user_config_dir = get_user_config_dir(paths);
     int path_len = strlen(name) + strlen(".log") + strlen("-") + strlen(namedash);
     path_len += strlen(set_path) ? *set_path : strlen(user_config_dir) + strlen(LOGDIR);
 
@@ -85,8 +85,8 @@ static int create_log_path(const Client_Config *c_config, char *dest, int destsi
  * Return 0 on success.
  * Return -1 on failure.
  */
-static int init_logging_session(const Client_Config *c_config, const char *name, const char *selfkey,
-                                const char *otherkey, struct chatlog *log, Log_Type type)
+static int init_logging_session(const Client_Config *c_config, const Paths *paths, const char *name,
+                                const char *selfkey, const char *otherkey, struct chatlog *log, Log_Type type)
 {
     if (log == NULL) {
         return -1;
@@ -98,7 +98,7 @@ static int init_logging_session(const Client_Config *c_config, const char *name,
 
     char log_path[MAX_STR_SIZE];
 
-    const int path_len = create_log_path(c_config, log_path, sizeof(log_path), name, selfkey, otherkey);
+    const int path_len = create_log_path(c_config, paths, log_path, sizeof(log_path), name, selfkey, otherkey);
 
     if (path_len == -1 || path_len >= sizeof(log->path)) {
         return -1;
@@ -219,8 +219,8 @@ int log_enable(struct chatlog *log)
  * Return 0 on success.
  * Return -1 on failure.
  */
-int log_init(struct chatlog *log, const Client_Config *c_config, const char *name, const char *selfkey,
-             const char *otherkey, Log_Type type)
+int log_init(struct chatlog *log, const Client_Config *c_config, const Paths *paths, const char *name,
+             const char *selfkey, const char *otherkey, Log_Type type)
 {
     if (log == NULL) {
         return -1;
@@ -231,7 +231,7 @@ int log_init(struct chatlog *log, const Client_Config *c_config, const char *nam
         return -1;
     }
 
-    if (init_logging_session(c_config, name, selfkey, otherkey, log, type) == -1) {
+    if (init_logging_session(c_config, paths, name, selfkey, otherkey, log, type) == -1) {
         return -1;
     }
 
@@ -625,8 +625,8 @@ int load_chat_history(struct chatlog *log, ToxWindow *self, const Client_Config 
  * Return 0 on success or if no log exists.
  * Return -1 on failure.
  */
-int rename_logfile(Windows *windows, const Client_Config *c_config, const char *src, const char *dest,
-                   const char *selfkey, const char *otherkey, uint16_t window_id)
+int rename_logfile(Windows *windows, const Client_Config *c_config, const Paths *paths, const char *src,
+                   const char *dest, const char *selfkey, const char *otherkey, uint16_t window_id)
 {
     ToxWindow *toxwin = get_window_pointer_by_id(windows, window_id);
     struct chatlog *log = NULL;
@@ -650,16 +650,16 @@ int rename_logfile(Windows *windows, const Client_Config *c_config, const char *
     char newpath[MAX_STR_SIZE];
     char oldpath[MAX_STR_SIZE];
 
-    if (create_log_path(c_config, oldpath, sizeof(oldpath), src, selfkey, otherkey) == -1) {
+    if (create_log_path(c_config, paths, oldpath, sizeof(oldpath), src, selfkey, otherkey) == -1) {
         goto on_error;
     }
 
     if (!file_exists(oldpath)) {  // still need to rename path
-        init_logging_session(c_config, dest, selfkey, otherkey, log, LOG_TYPE_CHAT);
+        init_logging_session(c_config, paths, dest, selfkey, otherkey, log, LOG_TYPE_CHAT);
         return 0;
     }
 
-    const int new_path_len = create_log_path(c_config, newpath, sizeof(newpath), dest, selfkey, otherkey);
+    const int new_path_len = create_log_path(c_config, paths, newpath, sizeof(newpath), dest, selfkey, otherkey);
 
     if (new_path_len == -1 || new_path_len >= MAX_STR_SIZE) {
         goto on_error;

--- a/src/log.h
+++ b/src/log.h
@@ -9,6 +9,7 @@
 #ifndef LOG_H
 #define LOG_H
 
+#include "paths.h"
 #include "settings.h"
 
 struct chatlog {
@@ -44,9 +45,8 @@ typedef enum Log_Hint {
  * Return 0 on success.
  * Return -1 on failure.
  */
-int log_init(struct chatlog *log, const Client_Config *c_config, const char *name, const char *selfkey,
-             const char *otherkey,
-             Log_Type type);
+int log_init(struct chatlog *log, const Client_Config *c_config, const Paths *paths, const char *name,
+             const char *selfkey, const char *otherkey, Log_Type type);
 
 /* Writes a message to the log.
  *
@@ -88,7 +88,7 @@ int load_chat_history(struct chatlog *log, ToxWindow *self, const Client_Config 
  * Return 0 on success or if no log exists.
  * Return -1 on failure.
  */
-int rename_logfile(Windows *windows, const Client_Config *c_config, const char *src, const char *dest,
-                   const char *selfkey, const char *otherkey, uint16_t window_id);
+int rename_logfile(Windows *windows, const Client_Config *c_config, const Paths *paths, const char *src,
+                   const char *dest, const char *selfkey, const char *otherkey, uint16_t window_id);
 
 #endif /* LOG_H */

--- a/src/paths.c
+++ b/src/paths.c
@@ -1,0 +1,84 @@
+/*  paths.c
+ *
+ *  Copyright (C) 2014-2026 Toxic All Rights Reserved.
+ *
+ *  This file is part of Toxic. Toxic is free software licensed
+ *  under the GNU General Public License 3.0.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <pwd.h>
+#include <stdio.h>
+
+#include "paths.h"
+
+#ifndef NSS_BUFLEN_PASSWD
+#define NSS_BUFLEN_PASSWD 4096
+#endif
+
+static char *get_home_dir_env(void)
+{
+    struct passwd pwd;
+    struct passwd *pwdbuf = NULL;
+    char buf[NSS_BUFLEN_PASSWD];
+
+    const int rc = getpwuid_r(getuid(), &pwd, buf, NSS_BUFLEN_PASSWD, &pwdbuf);
+    const char *hmstr = (rc == 0 && pwdbuf != NULL) ? pwd.pw_dir : getenv("HOME");
+
+    if (hmstr == NULL) {
+        return NULL;
+    }
+
+    return strdup(hmstr);
+}
+
+Paths *paths_init(void)
+{
+    Paths *paths = calloc(1, sizeof(Paths));
+
+    if (paths == NULL) {
+        return NULL;
+    }
+
+    paths->home_dir = get_home_dir_env();
+
+    if (paths->home_dir == NULL) {
+        fprintf(stderr, "Failed to get home directory\n");
+    }
+
+    const char *xdg = getenv("XDG_CONFIG_HOME");
+
+    if (xdg != NULL) {
+        paths->xdg_config_home = strdup(xdg);
+    }
+
+    const char *sty = getenv("STY");
+
+    if (sty != NULL) {
+        paths->screen_socket = strdup(sty);
+    }
+
+    const char *tmux = getenv("TMUX");
+
+    if (tmux != NULL) {
+        paths->tmux_socket = strdup(tmux);
+    }
+
+    return paths;
+}
+
+void paths_free(Paths *paths)
+{
+    if (paths == NULL) {
+        return;
+    }
+
+    free(paths->home_dir);
+    free(paths->xdg_config_home);
+    free(paths->screen_socket);
+    free(paths->tmux_socket);
+    free(paths);
+}

--- a/src/paths.h
+++ b/src/paths.h
@@ -1,0 +1,33 @@
+/*  paths.h
+ *
+ *  Copyright (C) 2014-2026 Toxic All Rights Reserved.
+ *
+ *  This file is part of Toxic. Toxic is free software licensed
+ *  under the GNU General Public License 3.0.
+ */
+
+#ifndef PATHS_H
+#define PATHS_H
+
+typedef struct Paths {
+    char *home_dir;
+    char *xdg_config_home;
+    char *screen_socket; /* STY */
+    char *tmux_socket;   /* TMUX */
+} Paths;
+
+/**
+ * @brief Initialize paths by reading environment variables.
+ *
+ * @return A new Paths object, or NULL on error.
+ */
+Paths *paths_init(void);
+
+/**
+ * @brief Free the Paths object.
+ *
+ * @param paths The object to free.
+ */
+void paths_free(Paths *paths);
+
+#endif /* PATHS_H */

--- a/src/prompt.c
+++ b/src/prompt.c
@@ -659,7 +659,7 @@ static void prompt_init_log(Toxic *toxic)
     char myid[TOX_ADDRESS_SIZE];
     tox_self_get_address(toxic->tox, (uint8_t *) myid);
 
-    if (log_init(ctx->log, toxic->c_config, self->name, myid, NULL, LOG_TYPE_PROMPT) != 0) {
+    if (log_init(ctx->log, toxic->c_config, toxic->paths, self->name, myid, NULL, LOG_TYPE_PROMPT) != 0) {
         line_info_add(self, c_config, false, NULL, NULL, SYS_MSG, 0, 0, "Warning: Log failed to initialize.");
         return;
     }

--- a/src/settings.c
+++ b/src/settings.c
@@ -361,7 +361,7 @@ static void set_key_binding(int *key, const char **bind)
     }
 }
 
-bool settings_load_config_file(Run_Options *run_opts, const char *data_path)
+bool settings_load_config_file(Run_Options *run_opts, const Paths *paths, const char *data_path)
 {
     char tmp_path[MAX_STR_SIZE] = {0};
 
@@ -384,7 +384,7 @@ bool settings_load_config_file(Run_Options *run_opts, const char *data_path)
 
         snprintf(tmp_path, sizeof(tmp_path), "%s%s", tmp_data, TOXIC_CONF_FILE_EXT);
     } else {
-        char *user_config_dir = get_user_config_dir();
+        char *user_config_dir = get_user_config_dir(paths);
         snprintf(tmp_path, sizeof(tmp_path), "%s%stoxic%s", user_config_dir, CONFIGDIR, TOXIC_CONF_FILE_EXT);
         free(user_config_dir);
     }

--- a/src/settings.h
+++ b/src/settings.h
@@ -13,6 +13,7 @@
 
 #include <tox/tox.h>
 
+#include "paths.h"
 #include "run_options.h"
 #include "toxic_constants.h"
 
@@ -121,7 +122,7 @@ typedef struct Windows Windows;
  *
  * Returns true if config file is successfully loaded.
  */
-bool settings_load_config_file(Run_Options *run_opts, const char *data_path);
+bool settings_load_config_file(Run_Options *run_opts, const Paths *paths, const char *data_path);
 
 /*
  * Loads general toxic settings from the toxic config file pointed to by `patharg'.

--- a/src/toxic.c
+++ b/src/toxic.c
@@ -48,6 +48,7 @@
 #include "misc_tools.h"
 #include "name_lookup.h"
 #include "notify.h"
+#include "paths.h"
 #include "prompt.h"
 #include "run_options.h"
 #include "settings.h"
@@ -87,6 +88,7 @@ static void kill_toxic(Toxic *toxic)
     free(toxic->c_config);
     free(toxic->run_opts);
     free(toxic->windows);
+    paths_free(toxic->paths);
     free(toxic);
 }
 

--- a/src/toxic.h
+++ b/src/toxic.h
@@ -62,6 +62,7 @@ typedef struct Client_Data {
 typedef struct ToxAV ToxAV;
 typedef struct ToxWindow ToxWindow;
 typedef struct Run_Options Run_Options;
+typedef struct Paths Paths;
 
 #define MAX_FRIEND_REQUESTS 20
 
@@ -101,6 +102,7 @@ typedef struct Toxic {
     Windows       *windows;
 
     FriendRequests frnd_requests;
+    Paths         *paths;
 } Toxic;
 
 typedef struct Init_Queue Init_Queue;


### PR DESCRIPTION
Adds `Paths` object to encapsulate environment-dependent paths (HOME, XDG_CONFIG_HOME, etc.) and pass it through the application context, removing direct calls to `getenv()` scattered throughout the codebase.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/toxic/411)
<!-- Reviewable:end -->
