### PR TITLE
fix: Ensure fatal error messages are printed to stderr

### DIFF
--- a/src/toxic.c
+++ b/src/toxic.c
@@ -141,14 +141,14 @@ void exit_toxic_err(int errcode, const char *errmsg, ...)
 {
     endwin();
 
-    if (freopen("/dev/tty", "w", stderr)) {
-        va_list args;
-        va_start(args, errmsg);
-        vfprintf(stderr, errmsg, args);
-        va_end(args);
+    freopen("/dev/tty", "w", stderr);
 
-        fprintf(stderr, "; toxic session aborted with error code %d\n", errcode);
-    }
+    va_list args;
+    va_start(args, errmsg);
+    vfprintf(stderr, errmsg, args);
+    va_end(args);
+
+    fprintf(stderr, "; toxic session aborted with error code %d\n", errcode);
 
     exit(EXIT_FAILURE);
 }


### PR DESCRIPTION
Modified exit_toxic_err to ensure the error message is printed to stderr even if /dev/tty cannot be opened. This ensures fatal errors are visible in non-interactive environments where /dev/tty might not be available.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/toxic/412)
<!-- Reviewable:end -->
