### PR TITLE
refactor: Eliminate Friends global variable (step 1).

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -45,7 +45,13 @@ void api_display(const char *const msg)
 
 FriendsList api_get_friendslist(void)
 {
-    return Friends;
+    if (user_toxic == NULL || user_toxic->friends == NULL) {
+        return (FriendsList) {
+            0
+        };
+    }
+
+    return *user_toxic->friends;
 }
 
 char *api_get_nick(void)

--- a/src/audio_call.c
+++ b/src/audio_call.c
@@ -419,7 +419,7 @@ void audio_bit_rate_callback(ToxAV *av, uint32_t friend_number, uint32_t audio_b
 
 void callback_recv_invite(Toxic *toxic, uint32_t friend_number)
 {
-    if (friend_number >= Friends.max_idx) {
+    if (toxic == NULL || friend_number >= toxic->friends->max_idx) {
         return;
     }
 
@@ -427,15 +427,15 @@ void callback_recv_invite(Toxic *toxic, uint32_t friend_number)
         return;
     }
 
-    if (Friends.list[friend_number].window_id == -1) {
-        const int window_id = add_window(toxic, new_chat(toxic->tox, Friends.list[friend_number].num));
+    if (toxic->friends->list[friend_number].window_id == -1) {
+        const int window_id = add_window(toxic, new_chat(toxic->friends, toxic->friends->list[friend_number].num));
 
         if (window_id < 0) {
             fprintf(stderr, "Failed to create new chat window in callback_recv_invite()\n");
             return;
         }
 
-        Friends.list[friend_number].window_id = window_id;
+        toxic->friends->list[friend_number].window_id = window_id;
     }
 
     const Call *call = &CallControl.calls[friend_number];

--- a/src/avatars.h
+++ b/src/avatars.h
@@ -11,6 +11,8 @@
 
 #include "file_transfers.h"
 
+typedef struct FriendsList FriendsList;
+
 #define MAX_AVATAR_FILE_SIZE 65536
 
 /* Sends avatar to friendnum.
@@ -18,21 +20,21 @@
  * Returns 0 on success.
  * Returns -1 on failure.
  */
-int avatar_send(Tox *tox, uint32_t friendnum);
+int avatar_send(FriendsList *friends, Tox *tox, uint32_t friendnum);
 
 /* Sets avatar to path and sends it to all online contacts.
  *
  * Returns 0 on success.
  * Returns -1 on failure.
  */
-int avatar_set(Tox *tox, const char *path, size_t length);
+int avatar_set(FriendsList *friends, Tox *tox, const char *path, size_t length);
 
 /* Unsets avatar and sends to all online contacts.
  *
  * Returns 0 on success.
  * Returns -1 on failure.
  */
-void avatar_unset(Tox *tox);
+void avatar_unset(FriendsList *friends, Tox *tox);
 
 void on_avatar_chunk_request(Toxic *toxic, struct FileTransfer *ft, uint64_t position, size_t length);
 void on_avatar_file_control(Toxic *toxic, struct FileTransfer *ft, Tox_File_Control control);

--- a/src/chat.h
+++ b/src/chat.h
@@ -12,10 +12,12 @@
 #include "toxic.h"
 #include "windows.h"
 
+typedef struct FriendsList FriendsList;
+
 /* set CTRL to -1 if we don't want to send a control signal.
    set msg to NULL if we don't want to display a message */
 void chat_close_file_receiver(Tox *tox, int filenum, int friendnum, int CTRL);
 void kill_chat_window(ToxWindow *self, Toxic *tox);
-ToxWindow *new_chat(Tox *tox, uint32_t friendnum);
+ToxWindow *new_chat(FriendsList *friends, uint32_t friendnum);
 
 #endif /* end of include guard: CHAT_H */

--- a/src/conference.c
+++ b/src/conference.c
@@ -970,11 +970,11 @@ static bool conference_onKey(ToxWindow *self, Toxic *toxic, wint_t key, bool ltr
             } else if (wcsncmp(ctx->line, L"/avatar ", wcslen(L"/avatar ")) == 0) {
                 diff = dir_match(self, toxic, ctx->line, L"/avatar");
             } else if (wcsncmp(ctx->line, L"/cinvite ", wcslen(L"/cinvite ")) == 0) {
-                size_t num_friends = friendlist_get_count();
+                size_t num_friends = friendlist_get_count(toxic->friends);
                 char **friend_names = (char **) malloc_ptr_array(num_friends, TOX_MAX_NAME_LENGTH);
 
                 if (friend_names != NULL) {
-                    friendlist_get_names(friend_names, num_friends, TOX_MAX_NAME_LENGTH);
+                    friendlist_get_names(toxic->friends, friend_names, num_friends, TOX_MAX_NAME_LENGTH);
                     diff = complete_line(self, toxic, (const char *const *) friend_names, num_friends);
                     free_ptr_array((void **) friend_names);
                 } else {

--- a/src/conference_commands.c
+++ b/src/conference_commands.c
@@ -69,7 +69,7 @@ void cmd_conference_invite(WINDOW *window, ToxWindow *self, Toxic *toxic, int ar
     }
 
     const char *nick = argv[1];
-    const int64_t friend_number = get_friend_number_name(nick, strlen(nick));
+    const int64_t friend_number = get_friend_number_name(toxic->friends, nick, strlen(nick));
 
     if (friend_number == -1) {
         line_info_add(self, c_config, false, NULL, NULL, SYS_MSG, 0, 0,

--- a/src/file_transfers.h
+++ b/src/file_transfers.h
@@ -20,6 +20,8 @@
 #define MiB (uint32_t) (1024 << 10)  /* 1024^2 */
 #define GiB (uint32_t) (1024 << 20)  /* 1024^3 */
 
+typedef struct FriendsList FriendsList;
+
 #define MAX_FILES 32
 
 typedef enum FILE_TRANSFER_STATE {
@@ -71,24 +73,25 @@ void print_progress_bar(ToxWindow *self, double pct_done, double bps, uint32_t l
  *
  * Return true if there is at least one active file transfer in either direction.
  */
-bool refresh_file_transfer_progress(ToxWindow *self, uint32_t friendnumber);
+bool refresh_file_transfer_progress(FriendsList *friends, ToxWindow *self, uint32_t friendnumber);
 
 /* Returns a pointer to friendnumber's FileTransfer struct associated with filenumber.
  * Returns NULL if filenumber is invalid.
  */
-struct FileTransfer *get_file_transfer_struct(uint32_t friendnumber, uint32_t filenumber);
+struct FileTransfer *get_file_transfer_struct(FriendsList *friends, uint32_t friendnumber, uint32_t filenumber);
 
 
 /* Returns a pointer to the FileTransfer struct associated with index with the direction specified.
  * Returns NULL on failure.
  */
-struct FileTransfer *get_file_transfer_struct_index(uint32_t friendnumber, uint32_t index,
+struct FileTransfer *get_file_transfer_struct_index(FriendsList *friends, uint32_t friendnumber, uint32_t index,
         FILE_TRANSFER_DIRECTION direction);
 
 /* Initializes an unused file transfer and returns its pointer.
  * Returns NULL on failure.
  */
-struct FileTransfer *new_file_transfer(ToxWindow *window, uint32_t friendnumber, uint32_t filenumber,
+struct FileTransfer *new_file_transfer(FriendsList *friends, ToxWindow *window, uint32_t friendnumber,
+                                       uint32_t filenumber,
                                        FILE_TRANSFER_DIRECTION direction, uint8_t type);
 
 /* Adds a file designated by `file_path` of length `length` to the file transfer queue.
@@ -104,7 +107,7 @@ struct FileTransfer *new_file_transfer(ToxWindow *window, uint32_t friendnumber,
  * Return -1 if the length is invalid.
  * Return -2 if the send queue is full.
  */
-int file_send_queue_add(uint32_t friendnumber, const char *file_path, size_t length);
+int file_send_queue_add(FriendsList *friends, uint32_t friendnumber, const char *file_path, size_t length);
 
 /* Initiates all file transfers from the file send queue for friend designated by `friendnumber`. */
 void file_send_queue_check(ToxWindow *self, Toxic *toxic, uint32_t friendnumber);
@@ -114,7 +117,7 @@ void file_send_queue_check(ToxWindow *self, Toxic *toxic, uint32_t friendnumber)
  * Return 0 if a pending transfer was successfully removed
  * Return -1 if index does not designate a pending file transfer.
  */
-int file_send_queue_remove(uint32_t friendnumber, size_t index);
+int file_send_queue_remove(FriendsList *friends, uint32_t friendnumber, size_t index);
 
 /* Closes file transfer ft.
  *
@@ -133,6 +136,6 @@ void kill_all_file_transfers_friend(Toxic *toxic, uint32_t friendnumber);
 void kill_all_file_transfers(Toxic *toxic);
 
 /* Return true if any pending or active file receiver has the path `path`. */
-bool file_transfer_recv_path_exists(const char *path);
+bool file_transfer_recv_path_exists(const FriendsList *friends, const char *path);
 
 #endif /* FILE_TRANSFERS_H */

--- a/src/friendlist.h
+++ b/src/friendlist.h
@@ -104,7 +104,7 @@ typedef struct {
     uint64_t last_on;
 } BlockedFriend;
 
-typedef struct {
+typedef struct FriendsList {
     int num_selected;
     size_t num_friends;
     size_t num_online;
@@ -113,7 +113,7 @@ typedef struct {
     ToxicFriend *list;
 } FriendsList;
 
-extern FriendsList Friends;
+void init_friendlist(Toxic *toxic);
 
 ToxWindow *new_friendlist(void);
 void friendlist_onInit(ToxWindow *self, Toxic *toxic);
@@ -127,7 +127,7 @@ Tox_Connection get_friend_connection_status(uint32_t friendnumber);
 /*
  * Returns the number of friends in the friend list.
  */
-size_t friendlist_get_count(void);
+size_t friendlist_get_count(const FriendsList *friends);
 
 /*
  * Copies names from the friends list into the `names` array.
@@ -135,7 +135,7 @@ size_t friendlist_get_count(void);
  * @max_names The maximum number of names to copy.
  * @max_name_size The maximum number of bytes to copy per name.
  */
-void friendlist_get_names(char **names, size_t max_names, size_t max_name_size);
+void friendlist_get_names(const FriendsList *friends, char **names, size_t max_names, size_t max_name_size);
 
 /*
  * Loads the list of blocked peers from `path`.
@@ -173,7 +173,7 @@ bool friend_get_auto_accept_files(uint32_t friendnumber);
  *
  * Returns the length of the name.
  */
-uint16_t get_friend_name(char *buf, size_t buf_size, uint32_t friendnumber);
+uint16_t get_friend_name(const FriendsList *friends, char *buf, size_t buf_size, uint32_t friendnumber);
 
 /*
  * Returns the friend number associated with `name`.
@@ -183,7 +183,7 @@ uint16_t get_friend_name(char *buf, size_t buf_size, uint32_t friendnumber);
  * Returns -1 if `name` does not designate a friend in the friend list.
  * Returns -2 if `name` matches more than one friend in the friend list.
  */
-int64_t get_friend_number_name(const char *name, uint16_t length);
+int64_t get_friend_number_name(const FriendsList *friends, const char *name, uint16_t length);
 
 /*
  * Puts a friend's public key in `pk`, which must have room for at least

--- a/src/game_base.c
+++ b/src/game_base.c
@@ -53,7 +53,7 @@ extern struct Winthread Winthread;
                                                  && ((max_x) >= (GAME_MAX_RECT_X_LARGE)))
 
 
-static ToxWindow *game_new_window(Tox *tox, GameType type, uint32_t friendnumber);
+static ToxWindow *game_new_window(FriendsList *friends, GameType type, uint32_t friendnumber);
 
 struct GameList {
     const char *name;
@@ -252,7 +252,7 @@ int game_initialize(const ToxWindow *parent, Toxic *toxic, GameType type, uint32
 
     max_y -= (CHATBOX_HEIGHT + WINDOW_BAR_HEIGHT);
 
-    ToxWindow *self = game_new_window(toxic->tox, type, parent->num);
+    ToxWindow *self = game_new_window(toxic->friends, type, parent->num);
 
     if (self == NULL) {
         return -4;
@@ -886,7 +886,7 @@ static void game_onPacket(ToxWindow *self, Toxic *toxic, uint32_t friendnumber, 
     }
 }
 
-static ToxWindow *game_new_window(Tox *tox, GameType type, uint32_t friendnumber)
+static ToxWindow *game_new_window(FriendsList *friends, GameType type, uint32_t friendnumber)
 {
     const char *window_name = game_get_name_string(type);
 
@@ -919,7 +919,7 @@ static ToxWindow *game_new_window(Tox *tox, GameType type, uint32_t friendnumber
 
     if (game_type_is_multi_only(type)) {
         char name[TOXIC_MAX_NAME_LENGTH + 1];
-        get_friend_name(name, sizeof(name), friendnumber);
+        get_friend_name(friends, name, sizeof(name), friendnumber);
 
         char buf[sizeof(name) + sizeof(ret->name) + 4];
         snprintf(buf, sizeof(buf), "%s (%s)", window_name, name);

--- a/src/global_commands.c
+++ b/src/global_commands.c
@@ -224,7 +224,7 @@ void cmd_avatar(WINDOW *window, ToxWindow *self, Toxic *toxic, int argc, char (*
     const Client_Config *c_config = toxic->c_config;
 
     if (argc != 1 || strlen(argv[1]) < 3) {
-        avatar_unset(tox);
+        avatar_unset(toxic->friends, tox);
         line_info_add(self, c_config, false, NULL, NULL, SYS_MSG, 0, 0, "Avatar has been unset.");
         return;
     }
@@ -246,7 +246,7 @@ void cmd_avatar(WINDOW *window, ToxWindow *self, Toxic *toxic, int argc, char (*
         return;
     }
 
-    if (avatar_set(tox, path, len) == -1) {
+    if (avatar_set(toxic->friends, tox, path, len) == -1) {
         line_info_add(self, c_config, false, NULL, NULL, SYS_MSG, 0, 0,
                       "Failed to set avatar. Avatars must be in PNG format and may not exceed %d bytes.",
                       MAX_AVATAR_FILE_SIZE);

--- a/src/groupchat_commands.c
+++ b/src/groupchat_commands.c
@@ -184,7 +184,7 @@ void cmd_group_invite(WINDOW *window, ToxWindow *self, Toxic *toxic, int argc, c
     }
 
     const char *nick = argv[1];
-    const int64_t friend_number = get_friend_number_name(nick, strlen(nick));
+    const int64_t friend_number = get_friend_number_name(toxic->friends, nick, strlen(nick));
 
     if (friend_number == -1) {
         line_info_add(self, c_config, false, NULL, NULL, SYS_MSG, 0, 0,

--- a/src/groupchats.c
+++ b/src/groupchats.c
@@ -1937,11 +1937,11 @@ static bool groupchat_onKey(ToxWindow *self, Toxic *toxic, wint_t key, bool ltr)
             int diff;
 
             if (wcsncmp(ctx->line, L"/invite ", wcslen(L"/invite ")) == 0) {
-                size_t num_friends = friendlist_get_count();
+                size_t num_friends = friendlist_get_count(toxic->friends);
                 char **friend_names = (char **) malloc_ptr_array(num_friends, TOX_MAX_NAME_LENGTH);
 
                 if (friend_names != NULL) {
-                    friendlist_get_names(friend_names, num_friends, TOX_MAX_NAME_LENGTH);
+                    friendlist_get_names(toxic->friends, friend_names, num_friends, TOX_MAX_NAME_LENGTH);
                     diff = complete_line(self, toxic, (const char *const *) friend_names, num_friends);
                     free_ptr_array((void **) friend_names);
                 } else {

--- a/src/main.c
+++ b/src/main.c
@@ -1206,6 +1206,8 @@ static Toxic *toxic_init(void)
 
     toxic->windows = tmp_windows;
 
+    init_friendlist(toxic);
+
     toxic->paths = paths_init();
 
     if (toxic->paths == NULL) {

--- a/src/toxic.h
+++ b/src/toxic.h
@@ -63,6 +63,7 @@ typedef struct ToxAV ToxAV;
 typedef struct ToxWindow ToxWindow;
 typedef struct Run_Options Run_Options;
 typedef struct Paths Paths;
+struct FriendsList;
 
 #define MAX_FRIEND_REQUESTS 20
 
@@ -85,6 +86,7 @@ typedef struct Windows {
 } Windows;
 
 typedef struct Toxic {
+    struct FriendsList *friends;
     Tox   *tox;
 #ifdef AUDIO
     ToxAV *av;

--- a/src/windows.c
+++ b/src/windows.c
@@ -290,7 +290,7 @@ void on_file_chunk_request(Tox *tox, uint32_t friendnumber, uint32_t filenumber,
     Toxic *toxic = (Toxic *) userdata;
     Windows *windows = toxic->windows;
 
-    FileTransfer *ft = get_file_transfer_struct(friendnumber, filenumber);
+    FileTransfer *ft = get_file_transfer_struct(toxic->friends, friendnumber, filenumber);
 
     if (ft == NULL) {
         return;
@@ -317,7 +317,7 @@ void on_file_recv_chunk(Tox *tox, uint32_t friendnumber, uint32_t filenumber, ui
     Toxic *toxic = (Toxic *) userdata;
     Windows *windows = toxic->windows;
 
-    const FileTransfer *ft = get_file_transfer_struct(friendnumber, filenumber);
+    const FileTransfer *ft = get_file_transfer_struct(toxic->friends, friendnumber, filenumber);
 
     if (ft == NULL) {
         return;
@@ -339,7 +339,7 @@ void on_file_recv_control(Tox *tox, uint32_t friendnumber, uint32_t filenumber, 
     Toxic *toxic = (Toxic *) userdata;
     Windows *windows = toxic->windows;
 
-    FileTransfer *ft = get_file_transfer_struct(friendnumber, filenumber);
+    FileTransfer *ft = get_file_transfer_struct(toxic->friends, friendnumber, filenumber);
 
     if (ft == NULL) {
         return;


### PR DESCRIPTION
Pass FriendsList via Toxic context instead of using a global variable. Moved the global definition to a static variable in friendlist.c.

This does *not* make FriendsList non-global yet, but this is a large refactoring, so I'm doing it in steps. The first step is to update most uses of it. Next step is to update friendslist.c to accept parameters instead of using the static variable. Last step is making it actually per-toxic-instance.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/toxic/413)
<!-- Reviewable:end -->
