### PR TITLE
refactor: Eliminate Friends global variable (step 3).

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1214,6 +1214,7 @@ static Toxic *toxic_init(void)
         free(toxic->c_config);
         free(toxic->run_opts);
         free(toxic->windows);
+        free(toxic->friends);
         free(toxic);
         return NULL;
     }

--- a/src/misc_tools.c
+++ b/src/misc_tools.c
@@ -295,6 +295,32 @@ int qsort_ptr_char_array_helper(const void *str1, const void *str2)
     return strcasecmp(*(const char *const *)str1, *(const char *const *)str2);
 }
 
+struct qsort_r_data {
+    void *arg;
+    int (*compar)(const void *, const void *, void *);
+};
+
+#ifdef __APPLE__
+static int qsort_r_compar_apple(void *thunk, const void *a, const void *b)
+{
+    struct qsort_r_data *data = thunk;
+    return data->compar(a, b, data->arg);
+}
+
+#endif
+
+void toxic_qsort_r(void *base, size_t nmemb, size_t size,
+                   int (*compar)(const void *, const void *, void *),
+                   void *arg)
+{
+#if defined(__APPLE__)
+    struct qsort_r_data data = { arg, compar };
+    qsort_r(base, nmemb, size, &data, qsort_r_compar_apple);
+#else
+    qsort_r(base, nmemb, size, compar, arg);
+#endif
+}
+
 /* List of characters we don't allow in nicks. */
 static const char invalid_nick_chars[] = {':', '/', '\0', '\a', '\b', '\f', '\n', '\r', '\t', '\v'};
 

--- a/src/misc_tools.h
+++ b/src/misc_tools.h
@@ -151,6 +151,17 @@ int qsort_strcasecmp_hlpr(const void *str1, const void *str2);
 /* case-insensitive string compare function for use with qsort */
 int qsort_ptr_char_array_helper(const void *str1, const void *str2);
 
+/* Portable wrapper for qsort_r.
+ *
+ * Signature matches the GNU version:
+ * void qsort_r(void *base, size_t nmemb, size_t size,
+ *             int (*compar)(const void *, const void *, void *),
+ *             void *arg);
+ */
+void toxic_qsort_r(void *base, size_t nmemb, size_t size,
+                   int (*compar)(const void *, const void *, void *),
+                   void *arg);
+
 /* Returns true if nick is valid.
  *
  * A valid toxic nick:

--- a/src/toxic.c
+++ b/src/toxic.c
@@ -88,6 +88,7 @@ static void kill_toxic(Toxic *toxic)
     free(toxic->c_config);
     free(toxic->run_opts);
     free(toxic->windows);
+    free(toxic->friends);
     paths_free(toxic->paths);
     free(toxic);
 }


### PR DESCRIPTION
Complete the transition to per-instance FriendsList by heap-allocating it within the Toxic struct and removing the static instance in friendlist.c.

Includes a new portable toxic_qsort_r wrapper to eliminate the need for static state during friend list sorting.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/toxic/415)
<!-- Reviewable:end -->
