### PR TITLE
chore: Statically link tests in bazel.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -19,9 +19,12 @@ COPTS = [
     "//tools/config:linux-x86_64": [
         "-DAUDIO",
         "-DVIDEO",
-        "-DPYTHON",
         "-DTOX_EXPERIMENTAL",
     ],
+    "//conditions:default": [],
+}) + select({
+    "//tools/config:linux-x86_64": ["-DPYTHON"],
+    "//tools/config:linux-x86_64-no-python": [],
     "//conditions:default": [],
 })
 
@@ -50,10 +53,13 @@ cc_library(
         "//tools/config:linux-x86_64": [
             "@libvpx",
             "@openal",
-            "@python3//:python",
             "@x11",
             "@xproto",
         ],
+        "//conditions:default": [],
+    }) + select({
+        "//tools/config:linux-x86_64": ["@python3//:python"],
+        "//tools/config:linux-x86_64-no-python": [],
         "//conditions:default": [],
     }),
 )
@@ -74,9 +80,12 @@ cc_binary(
         "//tools/config:linux-x86_64": [
             "@libvpx",
             "@openal",
-            "@python3//:python",
             "@x11",
         ],
+        "//conditions:default": [],
+    }) + select({
+        "//tools/config:linux-x86_64": ["@python3//:python"],
+        "//tools/config:linux-x86_64-no-python": [],
         "//conditions:default": [],
     }),
 )
@@ -93,6 +102,7 @@ cc_test(
     name = "line_info_test",
     size = "small",
     srcs = ["src/line_info_test.cc"],
+    linkstatic = True,
     tags = ["no-windows"],
     deps = [
         ":libtoxic",
@@ -105,6 +115,7 @@ cc_test(
     name = "misc_tools_test",
     size = "small",
     srcs = ["src/misc_tools_test.cc"],
+    linkstatic = True,
     tags = ["no-windows"],
     deps = [
         ":libtoxic",

--- a/script/build-minimal-static-toxic.sh
+++ b/script/build-minimal-static-toxic.sh
@@ -142,11 +142,11 @@ mkdir -p "$BUILD_DIR"
 # Build Toxcore
 cd "$BUILD_DIR"
 
-# The git hash of the c-toxcore version we're using
-TOXCORE_VERSION="da26052603369045dceb5dfc8c89919b222d0ce0"
+# The git hash of the c-toxcore version we're using (v0.2.23-rc.1)
+TOXCORE_VERSION="bab03670b21f640dd97076f8eea81cc159b0f1e1"
 
 # The sha256sum of the c-toxcore tarball for TOXCORE_VERSION
-TOXCORE_HASH="7fe83bbcc0034462d390f85d277365a1c0afcae58cdab54b5f7564c6c4a7030f"
+TOXCORE_HASH="dbbd8272609be8edc8b2a8f4c0ff46356fae052c3637d8465ad81d02dc0c1e32"
 
 TOXCORE_FILENAME="c-toxcore-$TOXCORE_VERSION.tar.gz"
 

--- a/src/main.c
+++ b/src/main.c
@@ -192,7 +192,7 @@ static void load_groups(Toxic *toxic)
 
     Tox *tox = toxic->tox;
 
-    size_t numgroups = tox_group_get_number_groups(tox);
+    size_t numgroups = tox_group_get_group_list_size(tox);
 
     for (size_t i = 0; i < numgroups; ++i) {
         if (init_groupchat_win(toxic, i, NULL, 0, Group_Join_Type_Load) != 0) {

--- a/src/python_api.c
+++ b/src/python_api.c
@@ -291,7 +291,7 @@ void init_python(Toxic *toxic)
     PyEval_SaveThread();
 }
 
-void run_python(FILE *fp, char *path)
+void run_python(FILE *fp, const char *path)
 {
     PyGILState_STATE gstate = PyGILState_Ensure();
 

--- a/src/python_api.h
+++ b/src/python_api.h
@@ -20,7 +20,7 @@
 PyMODINIT_FUNC PyInit_toxic_api(void);
 void terminate_python(void);
 void init_python(Toxic *toxic);
-void run_python(FILE *fp, char *path);
+void run_python(FILE *fp, const char *path);
 int do_python_command(int num_args, char (*args)[MAX_STR_SIZE]);
 int python_num_registered_handlers(void);
 int python_help_max_width(void);

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -19,7 +19,7 @@ RUN ["apk", "add", "--no-cache", \
  "yarn"]
 
 WORKDIR /build
-RUN yarn add --dev @microsoft/tui-test
+RUN yarn add --dev @microsoft/tui-test@0.0.1-rc.5
 ENV PATH=$PATH:/build/node_modules/.bin
 
 WORKDIR /build


### PR DESCRIPTION
Some curl weirdness. We didn't have this with our own custom curl build, but the bzlmod one has something weird about it. Still, better to use someone else's maintained curl build than our own, even with this slight oddity.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/toxic/428)
<!-- Reviewable:end -->
