### PR TITLE
fix: Python API memory/file descriptor leaks

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -102,6 +102,7 @@ void api_send(const char *msg)
     self_window = get_active_window(user_toxic->windows);
 
     if (self_window == NULL) {
+        free(name);
         return;
     }
 
@@ -231,6 +232,7 @@ void invoke_autoruns(ToxWindow *self, const char *autorun_path, Init_Queue *init
 
             if (file_type(abspath_buf) != FILE_TYPE_REGULAR) {
                 init_queue_add(init_q, "Python API error: Not a regular file: %s", abspath_buf);
+                fclose(fp);
                 continue;
             }
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/toxic/436)
<!-- Reviewable:end -->
